### PR TITLE
Add pypi spevific readme

### DIFF
--- a/README_pypi.md
+++ b/README_pypi.md
@@ -1,10 +1,4 @@
-<a href="https://test.pypi.org/project/djelm/0.1.1/" style="display: none;">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/confidenceman02/django-elm/main/assets/icon.png" width="140">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/confidenceman02/django-elm/main/assets/icon.png" width="140">
-    <img src="https://raw.githubusercontent.com/confidenceman02/django-elm/main/assets/icon.png" alt="Logo">
-  </picture>
-</a>
+<img alt="ContourPy" src="https://raw.githubusercontent.com/confidenceman02/django-elm/main/assets/icon.png" width="140">
 
 # Djelm
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "djelm"
 version = "0.1.0"
 description = "A framework for using Elm programs in a Django project"
 authors = ["Confidenceman02"]
-readme = "README.md"
+readme = "README_pypi.md"
 keywords = ["django", "elm"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
pypi doesn't render the picture tag correctly, so this readme uses the img tag instead.