### PR TITLE
Support custom types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ example/db.sqlite3
 .hypothesis/
 venv
 .doit.db
+.doit.db.db
 **/*.DS_Store

--- a/README.md
+++ b/README.md
@@ -579,6 +579,8 @@ init f =
 To summarize, we get compile and runtime guarantees that our program will behave as we expect. This is what makes Elm programs
 incredibly robust and nearly impossible to produce a runtime exception with.
 
+You can check out all the python flags you can use to express your data shape [here](https://github.com/Confidenceman02/django-elm/blob/main/src/djelm/flags/README.md).
+
 ## `generatemodel` Command
 
 Our python flag classes have a little trick up their sleeve that makes keeping both our python and Elm flag contracts in

--- a/src/djelm/codegen/annotation.py
+++ b/src/djelm/codegen/annotation.py
@@ -1,0 +1,91 @@
+from typing import List
+import djelm.codegen.compiler as Compiler
+import djelm.codegen.writer as Writer
+import djelm.codegen.format as Format
+from djelm.codegen.utils import foldl
+
+
+def getAliases(anno: Compiler.Annotation) -> dict[str, Compiler.TypeAnnotation]:
+    return anno.aliases
+
+
+def mergeAliases(
+    x: dict[str, Compiler.TypeAnnotation], anno: Compiler.Annotation
+) -> dict[str, Compiler.TypeAnnotation]:
+    z = x.copy()
+    z.update(getAliases(anno))
+    return z
+
+
+def toAliasKey(k: str) -> str:
+    return f"{k[0].upper()}{k[1:]}"
+
+
+def addAlias(
+    name: str,
+    target: Compiler.Annotation,
+    alias_cache: dict[str, Compiler.TypeAnnotation],
+) -> dict[str, Compiler.TypeAnnotation]:
+    aliasKey: str = toAliasKey(name)
+    alias_cache.update({f"{aliasKey}": target.annotation})
+    return alias_cache
+
+
+def typed(name: str, args: List[Compiler.Annotation]) -> Compiler.Annotation:
+    args_anno: List[Compiler.TypeAnnotation] = []
+    for arg in args:
+        args_anno.append(arg.annotation)
+
+    return Compiler.Annotation(
+        Compiler.Typed(name, args_anno),
+        foldl(mergeAliases, {}, args),
+    )
+
+
+def string():
+    """Elm String annotation"""
+    return typed("String", [])
+
+
+def int():
+    """Elm Int annotation"""
+    return typed("Int", [])
+
+
+def float():
+    """Elm Float annotation"""
+    return typed("Float", [])
+
+
+def bool() -> Compiler.Annotation:
+    """Elm Bool annotation"""
+    return typed("Bool", [])
+
+
+def maybe(anno: Compiler.Annotation):
+    """Elm Maybe annotation"""
+    return typed("Maybe", [anno])
+
+
+def list(anno: Compiler.Annotation):
+    """Elm List annotation"""
+    return typed("List", [anno])
+
+
+def alias(name: str, anno: Compiler.Annotation):
+    """Elm alias annotation"""
+    return Compiler.Annotation(
+        Compiler.Typed(Format.alias_type(name), []), addAlias(name, anno, {})
+    )
+
+
+def record(fields: List[tuple[str, Compiler.Annotation]]) -> Compiler.Annotation:
+    """Elm Dict annotation"""
+    return Compiler.Annotation(
+        Compiler.Record(fields),
+        foldl(lambda acc, field: mergeAliases(acc, field[1]), {}, fields),
+    )
+
+
+def toString(anno: Compiler.Annotation) -> str:
+    return Writer.writeTypeAnnotation(anno.annotation).write()

--- a/src/djelm/codegen/compiler.py
+++ b/src/djelm/codegen/compiler.py
@@ -1,0 +1,105 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List
+import djelm.codegen.range as Range
+
+
+class TypeAnnotation:
+    pass
+
+
+class Expression(ABC):
+    @abstractmethod
+    def annotation_type(self) -> TypeAnnotation | None:
+        pass
+
+    @abstractmethod
+    def set_range(self, rng: Range.Range) -> None:
+        pass
+
+    def set_range_column(self, start: int) -> None:
+        pass
+
+    @abstractmethod
+    def get_range(self) -> Range.Range:
+        pass
+
+
+class DeclarationKind:
+    pass
+
+
+@dataclass(slots=True)
+class Signature:
+    name: str
+    type_annotation: TypeAnnotation
+
+
+class Declaration:
+    def __init__(self, name: str, kind: DeclarationKind) -> None:
+        self.name = name
+        self.kind = kind
+
+
+@dataclass(slots=True)
+class Typed(TypeAnnotation):
+    def __init__(self, name: str, args: List[TypeAnnotation]) -> None:
+        self.name: str = name
+        self.args: List[TypeAnnotation] = args
+
+
+@dataclass(slots=True)
+class Generic(TypeAnnotation):
+    def __init__(self, value: str) -> None:
+        self.value: str = value
+
+
+class Annotation:
+    def __init__(
+        self,
+        annotation: TypeAnnotation,
+        aliases: dict[str, TypeAnnotation],
+    ) -> None:
+        self.annotation = annotation
+        self.aliases: dict[str, TypeAnnotation] = aliases
+
+
+class Variant:
+    def __init__(self, name: str, annotations: list[Annotation]) -> None:
+        self.name = name
+        self.annotations = annotations
+
+
+@dataclass(slots=True)
+class Record(TypeAnnotation):
+    def __init__(self, fields: List[tuple[str, Annotation]]) -> None:
+        self.fields = fields
+
+
+@dataclass(slots=True)
+class AliasDeclaration(DeclarationKind):
+    name: str
+    anno: Annotation
+
+
+@dataclass(slots=True)
+class CustomTypeDeclaration(DeclarationKind):
+    name: str
+    variants: list[Variant]
+
+
+@dataclass(slots=True)
+class FunctionDeclaration(DeclarationKind):
+    name: str
+    expression: Expression
+    signature: Signature
+
+
+def get_declaration_name(declaration: Declaration) -> str:
+    match declaration.kind:
+        case AliasDeclaration(name=name, anno=_):
+            return name
+        case CustomTypeDeclaration(name=name, variants=_):
+            return name
+        case _:
+            raise Exception("I don't recognise that declaration type")

--- a/src/djelm/codegen/elm.py
+++ b/src/djelm/codegen/elm.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import List
+
+import djelm.codegen.compiler as Compiler
+import djelm.codegen.format as Format
+import djelm.codegen.expression as Expression
+import djelm.codegen.module_name as Mod
+import djelm.codegen.range as Range
+
+
+def variantWith(name: str, annotations: List[Compiler.Annotation]) -> Compiler.Variant:
+    return Compiler.Variant(Format.safe_capitalize(name), annotations)
+
+
+def variant(name: str) -> Compiler.Variant:
+    return variantWith(name, [])
+
+
+def alias(name: str, annotation: Compiler.Annotation) -> Compiler.Declaration:
+    return Compiler.Declaration(
+        name, Compiler.AliasDeclaration(Format.alias_type(name), annotation)
+    )
+
+
+def customType(name: str, variants: List[Compiler.Variant]) -> Compiler.Declaration:
+    return Compiler.Declaration(
+        name, Compiler.CustomTypeDeclaration(Format.alias_type(name), variants)
+    )
+
+
+def value(
+    name: str,
+    rng: Range.Range | None = None,
+    annotation: Compiler.Annotation | None = None,
+) -> Compiler.Expression:
+    return Expression.FunctionOrValue(Mod.ModuleName([]), name, rng, annotation)
+
+
+def apply(
+    fnExp: Compiler.Expression,
+    argExp: List[Compiler.Expression],
+    rng: Range.Range | None = None,
+) -> Compiler.Expression:
+    return Expression.Application([fnExp, *argExp], fnExp.annotation_type(), rng)
+
+
+def list(members: List[Compiler.Expression]) -> Compiler.Expression:
+    return Expression.List(members, None)
+
+
+def literal(value: str) -> Compiler.Expression:
+    return Expression.Literal(value, None)
+
+
+def declaration(
+    name: str, expression: Compiler.Expression, signature: Compiler.Signature
+) -> Compiler.Declaration:
+    """Top level declaration"""
+    expression.set_range_column(4)
+    return Compiler.Declaration(
+        name,
+        Compiler.FunctionDeclaration(
+            name,
+            expression,
+            signature,
+        ),
+    )
+
+
+def int(value: int, rng: Range.Range | None = None) -> Compiler.Expression:
+    return Expression.Int(value, rng)
+
+
+@dataclass(slots=True)
+class CustomType:
+    name: str
+    variants: List[Compiler.Variant]

--- a/src/djelm/codegen/expression.py
+++ b/src/djelm/codegen/expression.py
@@ -1,0 +1,184 @@
+from dataclasses import dataclass
+import typing as Typ
+import djelm.codegen.module_name as Mod
+import djelm.codegen.range as Range
+import djelm.codegen.compiler as Compiler
+
+
+@dataclass(slots=True)
+class OperatorApplication(Compiler.Expression):
+    """Operators are constructed bottom up or right to left"""
+
+    symbol: str
+    infix_direction: Typ.Literal["Left"] | Typ.Literal["Right"] | Typ.Literal["Non"]
+    left: Compiler.Expression
+    right: Compiler.Expression
+    range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+        self.left.set_range(rng)
+
+    def set_range_column(self, start: int) -> None:
+        """
+        Set the start column for an operator application
+
+        This trickles in to the left hand side of the operator and allows
+        for correct indentation when lines are "breaked"
+
+        e.g.
+                someFunc =
+                    hello
+                        |> world
+                    ^   ^
+                    |   |
+                    |   start column + indentation
+                    start column
+
+        """
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+        self.left.set_range_column(start)
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class FunctionOrValue(Compiler.Expression):
+    moduleName: Mod.ModuleName
+    name: str
+    range: Range.Range | None
+    annotation: Compiler.Annotation | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        if self.annotation:
+            return self.annotation.annotation
+        else:
+            return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class Int(Compiler.Expression):
+    value: int
+    range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return Compiler.Typed("Int", [])
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class List(Compiler.Expression):
+    members: list[Compiler.Expression]
+    range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        match self.members:
+            case []:
+                return Compiler.Typed("List", [Compiler.Generic("a")])
+            case [head, _]:
+                head_anno: Compiler.TypeAnnotation | None = head.annotation_type()
+                if head_anno:
+                    return Compiler.Typed("List", [head_anno])
+                else:
+                    return Compiler.Typed("List", [Compiler.Generic("a")])
+            case _:
+                return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class Literal(Compiler.Expression):
+    value: str
+    range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return Compiler.Typed("String", [])
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class Application(Compiler.Expression):
+    expressions: list[Compiler.Expression]
+    annotation: Compiler.TypeAnnotation | None
+    range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class Parenthesized(Compiler.Expression):
+    expression: Compiler.Expression
+    range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)

--- a/src/djelm/codegen/format.py
+++ b/src/djelm/codegen/format.py
@@ -1,0 +1,10 @@
+def alias_type(k: str) -> str:
+    return f"{k[0].upper()}{k[1:]}"
+
+
+def safe_capitalize(k: str) -> str:
+    assert k
+    if 1 < len(k):
+        return f"{k[0].upper()}{k[1:]}"
+
+    return k[0].upper()

--- a/src/djelm/codegen/module_name.py
+++ b/src/djelm/codegen/module_name.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ModuleName:
+    names: list[str]

--- a/src/djelm/codegen/op.py
+++ b/src/djelm/codegen/op.py
@@ -1,0 +1,44 @@
+from typing import Iterator
+import djelm.codegen.expression as Exp
+import djelm.codegen.compiler as Compiler
+
+
+def plus(left: Compiler.Expression, right: Compiler.Expression) -> Compiler.Expression:
+    return Exp.OperatorApplication("+", "Left", left, right, None)
+
+
+def pipe(right: Compiler.Expression, left: Compiler.Expression) -> Compiler.Expression:
+    """Construct a pipe operator"""
+    return Exp.OperatorApplication("|>", "Left", left, right, None)
+
+
+def pipes(
+    top_pipe: Compiler.Expression, other_pipes: Iterator[Compiler.Expression]
+) -> Compiler.Expression:
+    """
+    Supply an iterator of expressions to build a pipe expression bottom to top
+
+    top_pipe = Should be the top most pipe in the chain.
+    e.g.
+            Decode.succeed Something
+            ^   |> required "something" Decode.string
+            |
+            top_pipe
+
+    other_pipes = The pipe tree will be constructed bottom to top so the iterator should reflect
+                  that order
+    e.g.
+            pipes(top_pipe, iter[1, 2, 3])
+
+            ==
+                top_pipe
+                   |> 3
+                   |> 2
+                   |> 1
+    """
+    try:
+        right_pipe = next(other_pipes)
+    except StopIteration:
+        return top_pipe
+
+    return pipe(right=right_pipe, left=pipes(top_pipe, other_pipes))

--- a/src/djelm/codegen/range.py
+++ b/src/djelm/codegen/range.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Range:
+    row: int
+    column: int

--- a/src/djelm/codegen/utils.py
+++ b/src/djelm/codegen/utils.py
@@ -1,0 +1,5 @@
+import functools
+
+
+def foldl(func, acc, xs):
+    return functools.reduce(func, xs, acc)

--- a/src/djelm/codegen/writer.py
+++ b/src/djelm/codegen/writer.py
@@ -1,0 +1,387 @@
+from dataclasses import dataclass
+from typing import List, Protocol
+import djelm.codegen.compiler as Compiler
+import djelm.codegen.expression as Exp
+import djelm.codegen.module_name as Mod
+
+
+class Writer(Protocol):
+    def write(self, indent: int = 0) -> str:
+        ...
+
+    def writeIndented(self, indent: int = 0) -> str:
+        if indent == 0:
+            return ""
+        repeated = ""
+
+        for _ in range(indent):
+            repeated += " "
+        return repeated
+
+
+@dataclass(slots=True)
+class Spaced(Writer):
+    items: List[Writer]
+
+    def write(self, indent: int = 0) -> str:
+        return " ".join([w.write(indent) for w in self.items])
+
+
+@dataclass(slots=True)
+class String(Writer):
+    val: str
+
+    def write(self, indent: int = 0) -> str:
+        return self.val
+
+
+@dataclass(slots=True)
+class Literal(Writer):
+    val: str
+
+    def write(self, indent: int = 0) -> str:
+        return f'"{ self.val }"'
+
+
+@dataclass(slots=True)
+class Paren(Writer):
+    writer: Writer
+
+    def write(self, indent: int = 0) -> str:
+        return f"({self.writer.write()})"
+
+
+@dataclass(slots=True)
+class Sep(Writer):
+    new_line: bool
+    separators: tuple[str, str, str]
+    items: List[Writer]
+
+    def write(self, indent: int = 0) -> str:
+        pre, sep, post = self.separators
+
+        if post != "":
+            post = self.writeIndented(indent) + post
+
+        if self.new_line:
+            post = "\n" + post
+            separator = "\n" + self.writeIndented(indent) + sep
+        else:
+            separator = sep
+
+        return f"{pre}{separator.join([w.write() for w in self.items])}{post}"
+
+
+@dataclass(slots=True)
+class SepInline(Writer):
+    separators: tuple[str, str, str]
+    items: List[Writer]
+
+    def write(self, indent: int = 0) -> str:
+        pre, sep, post = self.separators
+
+        return f"{pre}{sep.join([w.write() for w in self.items])}{post}"
+
+
+@dataclass(slots=True)
+class Breaked(Writer):
+    writers: List[Writer]
+
+    def write(self, indent: int = 0) -> str:
+        return "\n".join([w.write() for w in self.writers])
+
+
+@dataclass(slots=True)
+class Indent(Writer):
+    indent: int
+    writer: Writer
+
+    def write(self, indent: int = 0) -> str:
+        return f"{self.writeIndented(self.indent)}{self.writer.write(self.indent)}"
+
+
+@dataclass(slots=True)
+class Joined(Writer):
+    writer: List[Writer]
+
+    def write(self, indent: int = 0) -> str:
+        return "".join([w.write() for w in self.writer])
+
+
+def string(val: str) -> Writer:
+    return String(val)
+
+
+def literal(val: str) -> Writer:
+    return Literal(val)
+
+
+def spaced(items: List[Writer]) -> Writer:
+    return Spaced(items)
+
+
+def paren(writer: Writer) -> Writer:
+    return Paren(writer)
+
+
+def breaked(writers: List[Writer]) -> Writer:
+    return Breaked(writers)
+
+
+def indent(indent: int, writer: Writer) -> Writer:
+    return Indent(indent, writer)
+
+
+def multiFieldRecord(new_line: bool, items: List[Writer]) -> Writer:
+    return Sep(new_line, ("{ ", ", ", "}"), items)
+
+
+def bracesComma(new_line: bool, items: List[Writer]) -> Writer:
+    return Sep(new_line, ("{", ", ", "}"), items)
+
+
+def bracketsComma(new_line: bool, items: List[Writer]) -> Writer:
+    return Sep(new_line, ("[", ", ", "]"), items)
+
+
+def singleRecordField(items: List[Writer]) -> Writer:
+    return SepInline(("{ ", ", ", " }"), items)
+
+
+def sepBy(separators: tuple[str, str, str], newlines: bool, writers: list[Writer]):
+    return Sep(newlines, separators, writers)
+
+
+def join(writers: list[Writer]):
+    return Joined(writers)
+
+
+def epsilon():
+    return string("")
+
+
+def parensIfContainsSpaces(writer: Writer) -> Writer:
+    if " " in writer.write():
+        return paren(writer)
+    else:
+        return writer
+
+
+def writeTypeAnnotation(anno: Compiler.TypeAnnotation) -> Writer:
+    match anno:
+        case Compiler.Typed(name=name, args=args):
+            spaced_writer = Spaced(
+                [
+                    string(name),
+                    *[parensIfContainsSpaces(writeTypeAnnotation(w)) for w in args],
+                ]
+            )
+
+            return spaced_writer
+
+        case Compiler.Generic(value=value):
+            return string(value)
+
+        case Compiler.Record(fields=fields):
+            writer_fields = []
+            for field in fields:
+                writer_fields.append(
+                    spaced(
+                        [
+                            string(field[0]),
+                            string(":"),
+                            writeTypeAnnotation(field[1].annotation),
+                        ]
+                    )
+                )
+            if 1 < len(writer_fields):
+                return multiFieldRecord(True, writer_fields)
+            else:
+                return singleRecordField(writer_fields)
+
+        case _:
+            raise Exception("Can't handle that type of annotation")
+
+
+def writeVariantConstructors(variant: Compiler.Variant) -> Writer:
+    writers: list[Writer] = [string(variant.name)]
+    writers.extend(
+        [
+            parensIfContainsSpaces(writeTypeAnnotation(v.annotation))
+            for v in variant.annotations
+        ]
+    )
+    return spaced(writers)
+
+
+def writeModuleName(module: Mod.ModuleName) -> Writer:
+    return string(".".join(module.names))
+
+
+def writeExpression(expression: Compiler.Expression) -> Writer:
+    match expression:
+        case (
+            Exp.OperatorApplication(
+                symbol=symbol,
+                infix_direction=direction,
+                left=left,
+                right=right,
+                range=_,
+            ) as op
+        ):
+            op_range = op.get_range()
+            right_range = right.get_range()
+            left_range = left.get_range()
+            break_right = 0 < right_range.row
+            break_left = 0 < left_range.row
+
+            if break_right:
+                right_writer = indent(
+                    4 + op_range.column,
+                    spaced(
+                        [
+                            string(symbol),
+                            writeExpression(right),
+                        ]
+                    ),
+                )
+            else:
+                right_writer = spaced(
+                    [
+                        string(symbol),
+                        writeExpression(right),
+                    ]
+                )
+
+            if break_left:
+                left_writer = indent(4 + op_range.column, writeExpression(left))
+            else:
+                left_writer = writeExpression(left)
+
+            match direction:
+                case "Left":
+                    if break_right or break_left:
+                        return breaked(
+                            [
+                                left_writer,
+                                right_writer,
+                            ]
+                        )
+                    else:
+                        return spaced(
+                            [
+                                writeExpression(left),
+                                string(symbol),
+                                writeExpression(right),
+                            ]
+                        )
+
+                case "Right":
+                    return spaced(
+                        [
+                            writeExpression(left),
+                            writeExpression(right),
+                            string(symbol),
+                        ]
+                    )
+                case "Non":
+                    return spaced(
+                        [
+                            writeExpression(left),
+                            string(symbol),
+                            writeExpression(right),
+                        ]
+                    )
+        case Exp.FunctionOrValue(moduleName=module, name=name):
+            match module.names:
+                case []:
+                    return string(name)
+                case _:
+                    return join([writeModuleName(module), string("."), string(name)])
+        case Exp.Int(value=v, range=name):
+            return string(str(v))
+        case Exp.Literal(value=v, range=name):
+            return literal(v)
+        case Exp.Application(expressions=exp):
+            match exp:
+                case []:
+                    return epsilon()
+                case [x]:
+                    return writeExpression(x)
+                case [x, *x_rest]:
+                    return spaced(
+                        [
+                            writeExpression(x),
+                            sepBy(
+                                ("", " ", ""),
+                                False,
+                                [writeExpression(ex) for ex in x_rest],
+                            ),
+                        ]
+                    )
+                case _:
+                    raise Exception("Can't handle that type of espression")
+
+        case Exp.Parenthesized(expression=e):
+            return paren(writeExpression(e))
+
+        case Exp.List(members=members, range=_):
+            return bracketsComma(False, [writeExpression(m) for m in members])
+
+        case _:
+            raise Exception("Can't handle that expression type")
+
+
+def writeDeclartion(declaration: Compiler.Declaration) -> Writer:
+    """Writer for top level declarations"""
+    match declaration.kind:
+        case Compiler.AliasDeclaration(name=name, anno=anno):
+            return breaked(
+                [
+                    spaced(
+                        [
+                            string("type"),
+                            string("alias"),
+                            string(name),
+                            string("="),
+                        ]
+                    ),
+                    indent(4, writeTypeAnnotation(anno.annotation)),
+                ]
+            )
+        case Compiler.CustomTypeDeclaration(name=name, variants=variants):
+            return breaked(
+                [
+                    spaced([string("type"), string(name)]),
+                    indent(
+                        4,
+                        # TODO rstrip string to remove trailing spaces
+                        sepBy(
+                            ("= ", "| ", ""),
+                            True,
+                            [writeVariantConstructors(v) for v in variants],
+                        ),
+                    ),
+                ]
+            )
+        case Compiler.FunctionDeclaration(name=name, signature=sig, expression=exp):
+            return breaked(
+                [
+                    writeSignature(sig),
+                    spaced(
+                        [
+                            string(name),
+                            string("="),
+                        ]
+                    ),
+                    indent(4, writeExpression(exp)),
+                ]
+            )
+        case _:
+            raise Exception("Cant handle that type of annotation")
+
+
+def writeSignature(sig: Compiler.Signature) -> Writer:
+    return spaced(
+        [string(sig.name), string(":"), writeTypeAnnotation(sig.type_annotation)]
+    )

--- a/src/djelm/flags/README.md
+++ b/src/djelm/flags/README.md
@@ -1,0 +1,147 @@
+# Djelm flags
+
+## What are they?
+
+Flags are how we map python values from our django server to Elm primitives that our programs will be initiated with.
+
+You can think of them as a schema of sorts, that can do a number of extra tasks for us, such as:
+
+- Validate python values
+- Generate Elm decoders
+
+You can find a good explanation for djelm flags with examples in the official guide [here](https://github.com/Confidenceman02/django-elm?tab=readme-ov-file#flags).
+
+# StringFlag
+
+```python
+StringFlag()
+```
+
+```
+# python
+"foo" : str
+
+# elm
+"foo" : String
+```
+
+# IntFlag
+
+```python
+IntFlag()
+```
+
+```
+# python
+2 : int
+
+# elm
+2 : Int
+```
+
+# FloatFlag
+
+```python
+FloatFlag()
+```
+
+```
+# python
+2.0 : float
+
+# elm
+2.0 : Float
+```
+
+# BoolFlag
+
+```python
+BoolFlag()
+```
+
+```
+# python
+True : bool
+
+# elm
+True : Bool
+```
+
+# NullableFlag
+
+argument: Flag
+
+```python
+NullableFlag(StringFlag())
+```
+
+```
+# python
+None : str | None
+
+# elm
+Nothing : Maybe String
+
+# python
+"foo" : str | None
+
+# elm
+Just "foo" : Maybe String
+```
+
+# ListFlag
+
+argument: Flag
+
+```python
+ListFlag(StringFlag())
+```
+
+```
+# python
+["foo"] : list[str]
+
+# elm
+["foo"] : List String
+```
+
+# ObjectFlag
+
+argument: dict[str, Flag]
+
+```python
+ObjectFlag({"hello": StringFlag()})
+```
+
+```
+# python
+{"hello": "world"} : dict[str, str]
+
+# elm
+{ hello = "world" } : { hello : String }
+```
+
+# CustomTypeFlag
+
+Elm calls these custom types, but you may also know them as the following:
+
+- Discriminated unions
+- Tagged unions
+- Sum types
+- Algebraic data types
+
+argument: list[tuple[str, Flag]]
+
+```python
+CustomTypeFlag(variants=[("A", StringFlag()), ("B", IntFlag())])
+```
+
+```
+# python
+"hello" : Union[str, int]
+2       : Union[str, int]
+
+# elm
+A "hello" : Custom
+B 2       : Custom
+```

--- a/src/djelm/flags/__init__.py
+++ b/src/djelm/flags/__init__.py
@@ -7,6 +7,7 @@ from .primitives import (
     NullableFlag,
     ListFlag,
     ObjectFlag,
+    CustomTypeFlag,
 )
 
 from .main import Flags

--- a/src/djelm/flags/main.py
+++ b/src/djelm/flags/main.py
@@ -1,6 +1,14 @@
 import typing
 from dataclasses import dataclass
-
+import djelm.codegen.annotation as Anno
+import djelm.codegen.compiler as Compiler
+import djelm.codegen.expression as Exp
+import djelm.codegen.op as Op
+import djelm.codegen.module_name as Module
+import djelm.codegen.range as Range
+import djelm.codegen.format as Format
+import djelm.codegen.writer as Writer
+import djelm.codegen.elm as Elm
 from pydantic import BaseModel, TypeAdapter, validate_call
 from typing_extensions import Annotated
 from djelm.flags.form.adapters import ModelChoiceFieldAdapter
@@ -9,6 +17,7 @@ from djelm.flags.form.primitives import ModelChoiceFieldFlag
 
 from .primitives import (
     BoolFlag,
+    CustomTypeFlag,
     Flag,
     FloatFlag,
     IntFlag,
@@ -32,7 +41,6 @@ from .adapters import (
     annotated_float,
 )
 
-
 PreparedElm = typing.TypedDict("PreparedElm", {"alias_type": str, "decoder_body": str})
 
 
@@ -47,22 +55,37 @@ class StringDecoder:
 
     value: str
 
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {StringDecoder._raw_decoder()}"""
-
     def alias(self) -> str:
-        return f"""{self.value} : {StringDecoder._raw_type()}"""
+        return f"""{self.value} : {StringDecoder._annotation()}"""
 
     def nested_alias(self):
-        return f""", {self.value} : {StringDecoder._raw_type()}"""
+        return f""", {self.value} : {StringDecoder._annotation()}"""
 
     @staticmethod
     def _raw_decoder():
         return "Decode.string"
 
     @staticmethod
-    def _raw_type():
-        return "String"
+    def _annotation():
+        return Anno.toString(StringDecoder._compiler_annotation())
+
+    @staticmethod
+    def _compiler_annotation() -> Compiler.Annotation:
+        return Anno.string()
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [Elm.literal(self.value), self.decoder_expression()],
+            Range.Range(1, 0),
+        )
+
+    @staticmethod
+    def decoder_expression() -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "string", None, None),
+            [],
+        )
 
 
 @dataclass(slots=True)
@@ -71,22 +94,37 @@ class IntDecoder:
 
     value: str
 
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {IntDecoder._raw_decoder()}"""
-
     def alias(self):
-        return f"""{self.value} : {IntDecoder._raw_type()}"""
+        return f"""{self.value} : {IntDecoder._annotation()}"""
 
     def nested_alias(self):
-        return f""", {self.value} : {IntDecoder._raw_type()}"""
+        return f""", {self.value} : {IntDecoder._annotation()}"""
 
     @staticmethod
     def _raw_decoder():
         return "Decode.int"
 
     @staticmethod
-    def _raw_type():
-        return "Int"
+    def _annotation():
+        return Anno.toString(IntDecoder._compiler_annotation())
+
+    @staticmethod
+    def _compiler_annotation() -> Compiler.Annotation:
+        return Anno.int()
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [Elm.literal(self.value), self.decoder_expression()],
+            Range.Range(1, 0),
+        )
+
+    @staticmethod
+    def decoder_expression() -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "int", None, None),
+            [],
+        )
 
 
 @dataclass(slots=True)
@@ -95,22 +133,37 @@ class BoolDecoder:
 
     value: str
 
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {BoolDecoder._raw_decoder()}"""
-
     def alias(self):
-        return f"""{self.value} : {BoolDecoder._raw_type()}"""
+        return f"""{self.value} : {BoolDecoder._annotation()}"""
 
     def nested_alias(self):
-        return f""", {self.value} : {BoolDecoder._raw_type()}"""
+        return f""", {self.value} : {BoolDecoder._annotation()}"""
 
     @staticmethod
     def _raw_decoder():
         return "Decode.bool"
 
     @staticmethod
-    def _raw_type():
-        return "Bool"
+    def _annotation():
+        return Anno.toString(BoolDecoder._compiler_annotation())
+
+    @staticmethod
+    def _compiler_annotation() -> Compiler.Annotation:
+        return Anno.bool()
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [Elm.literal(self.value), self.decoder_expression()],
+            Range.Range(1, 0),
+        )
+
+    @staticmethod
+    def decoder_expression() -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "bool", None, None),
+            [],
+        )
 
 
 @dataclass(slots=True)
@@ -119,22 +172,37 @@ class FloatDecoder:
 
     value: str
 
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {FloatDecoder._raw_decoder()}"""
-
     def alias(self):
-        return f"""{self.value} : {FloatDecoder._raw_type()}"""
+        return f"""{self.value} : {FloatDecoder._annotation()}"""
 
     def nested_alias(self):
-        return f""", {self.value} : {FloatDecoder._raw_type()}"""
+        return f""", {self.value} : {FloatDecoder._annotation()}"""
 
     @staticmethod
     def _raw_decoder():
         return "Decode.float"
 
     @staticmethod
-    def _raw_type():
-        return "Float"
+    def _annotation():
+        return Anno.toString(FloatDecoder._compiler_annotation())
+
+    @staticmethod
+    def _compiler_annotation() -> Compiler.Annotation:
+        return Anno.float()
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [Elm.literal(self.value), self.decoder_expression()],
+            Range.Range(1, 0),
+        )
+
+    @staticmethod
+    def decoder_expression() -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "float", None, None),
+            [],
+        )
 
 
 @dataclass(slots=True)
@@ -143,24 +211,45 @@ class ListDecoder:
 
     value: str
     targetDecoderName: str
-    targetTypeName: str
-
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {ListDecoder._raw_decoder(self.targetDecoderName)}"""
+    target: Compiler.Annotation
 
     def alias(self):
-        return f"""{self.value} : {self._raw_type(self.targetTypeName)}"""
+        return f"""{self.value} : {self._annotation(self.target)}"""
 
     def nested_alias(self):
-        return f""", {self.value} : List {self.targetTypeName}"""
+        return f""", {self.value} : {self._annotation(self.target)}"""
 
     @staticmethod
     def _raw_decoder(decoder_def: str):
         return f"(Decode.list {decoder_def})"
 
     @staticmethod
-    def _raw_type(targetType: str):
-        return f"(List {targetType})"
+    def _annotation(annotation: Compiler.Annotation) -> str:
+        return Anno.toString(ListDecoder._compiler_annotation(annotation))
+
+    @staticmethod
+    def _compiler_annotation(annotation: Compiler.Annotation) -> Compiler.Annotation:
+        return Anno.list(annotation)
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [
+                Elm.literal(self.value),
+                self.decoder_expression(Elm.value(self.targetDecoderName)),
+            ],
+            Range.Range(1, 0),
+        )
+
+    @staticmethod
+    def decoder_expression(expression: Compiler.Expression) -> Compiler.Expression:
+        return Exp.Parenthesized(
+            Elm.apply(
+                Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "list", None, None),
+                [expression],
+            ),
+            None,
+        )
 
 
 @dataclass(slots=True)
@@ -169,24 +258,47 @@ class NullableDecoder:
 
     value: str
     targetDecoderName: str
-    targetTypeName: str
-
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {NullableDecoder._raw_decoder(self.targetDecoderName)}"""
+    target: Compiler.Annotation
 
     def alias(self):
-        return f"""{self.value} : Maybe {self.targetTypeName}"""
+        return f"""{self.value} : {self._annotation(self.target)}"""
 
     def nested_alias(self):
-        return f""", {self.value} : Maybe {self.targetTypeName}"""
+        return f""", {self.value} : {self._annotation(self.target)}"""
 
     @staticmethod
     def _raw_decoder(decoder_def: str):
         return f"(Decode.nullable {decoder_def})"
 
     @staticmethod
-    def _raw_type(targetType: str):
-        return f"(Maybe {targetType})"
+    def _annotation(annotation: Compiler.Annotation) -> str:
+        return Anno.toString(NullableDecoder._compiler_annotation(annotation))
+
+    @staticmethod
+    def _compiler_annotation(annotation: Compiler.Annotation) -> Compiler.Annotation:
+        return Anno.maybe(annotation)
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [
+                Elm.literal(self.value),
+                self.decoder_expression(Elm.value(self.targetDecoderName)),
+            ],
+            Range.Range(1, 0),
+        )
+
+    @staticmethod
+    def decoder_expression(expression: Compiler.Expression) -> Compiler.Expression:
+        return Exp.Parenthesized(
+            Elm.apply(
+                Exp.FunctionOrValue(
+                    Module.ModuleName(["Decode"]), "nullable", None, None
+                ),
+                [expression],
+            ),
+            None,
+        )
 
 
 @dataclass(slots=True)
@@ -197,40 +309,128 @@ class ObjectDecoder:
     depth: int
     parent_alias: str | None = None
 
-    def pipeline(self):
-        return f"""|>  required "{self.value}" {self._to_decoder_name()}"""
-
-    def pipeline_starter(self):
-        return f"""{self._to_decoder_annotation()}\n    {self._to_pipeline_succeed()}"""
+    def pipeline_signature(self) -> Compiler.Signature:
+        return Compiler.Signature(
+            self._to_decoder_name(),
+            Compiler.Typed(
+                "Decode.Decoder",
+                [self._compiler_annotation(Anno.record([])).annotation],
+            ),
+        )
 
     def alias(self):
-        return f"""{self.value} : {self._to_alias()}"""
+        return f"""{self.value} : {self._to_annotation()}"""
 
     def nested_alias(self):
-        return f""", {self.value} : {self._to_alias()}"""
+        return f""", {self.value} : {self._to_annotation()}"""
 
-    def _to_alias(self) -> str:
-        p = self.parent_alias if self.parent_alias else ""
-        return f"{p}{self.value[0].upper()}{self.value[1:]}{self._depth_markers()}"
-
-    def _to_decoder_annotation(self):
-        return f"""{self._to_decoder_name()} : Decode.Decoder {self._to_alias()}\n{self._to_decoder_name()} ="""
+    def _to_annotation(self) -> str:
+        anno = self._compiler_annotation(
+            Anno.record([]),
+        )
+        return Anno.toString(anno)
 
     def _to_decoder_name(self):
         p = self.parent_alias if self.parent_alias else ""
         return f"""{p.lower() + self.value + self._depth_markers()}Decoder"""
-
-    def _to_alias_definition(self, body: str):
-        return f"""\n\ntype alias {self._to_alias()} =\n    {body}"""
-
-    def _to_pipeline_succeed(self):
-        return f"""Decode.succeed {self._to_alias()}"""
 
     def _depth_markers(self) -> str:
         marker = ""
         for _ in range(self.depth):
             marker += "_"
         return marker
+
+    def _compiler_annotation(
+        self, annotation: Compiler.Annotation
+    ) -> Compiler.Annotation:
+        p = self.parent_alias if self.parent_alias else ""
+        return Anno.alias(
+            f"{p}{Format.alias_type(self.value)}{self._depth_markers()}", annotation
+        )
+
+    def pipeline_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [Elm.literal(self.value), self.decoder_expression()],
+            Range.Range(1, 0),
+        )
+
+    def pipeline_starter_expression(self) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "succeed", None, None),
+            [Elm.value(self._to_annotation())],
+        )
+
+    def decoder_expression(self) -> Compiler.Expression:
+        return Elm.value(self._to_decoder_name())
+
+
+@dataclass(slots=True)
+class CustomTypeDecoder:
+    """Decoder helper for the Elm custom type primitive"""
+
+    name: str
+    depth: int
+    compiler_variants: list[Compiler.Variant]
+    decoder_expressions: list[tuple[str, Compiler.Expression]]
+
+    @staticmethod
+    def pipeline_expression(
+        field: str, expression: Compiler.Expression
+    ) -> Compiler.Expression:
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+            [Elm.literal(field), expression],
+            Range.Range(1, 0),
+        )
+
+    def _to_annotation(self) -> str:
+        return Anno.toString(self._compiler_annotation())
+
+    def _to_declaration(self) -> str:
+        return Writer.writeDeclartion(self._compiler_declaration()).write()
+
+    def _compiler_annotation(self) -> Compiler.Annotation:
+        return Compiler.Annotation(
+            Compiler.Typed(
+                Format.alias_type(
+                    Compiler.get_declaration_name(self._compiler_declaration())
+                ),
+                [],
+            ),
+            {},
+        )
+
+    def _compiler_declaration(self) -> Compiler.Declaration:
+        return Elm.customType(self.name, self.compiler_variants)
+
+    def decoder_expression(self) -> Compiler.Expression:
+        return Exp.Parenthesized(
+            Elm.apply(
+                Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "oneOf", None, None),
+                [
+                    Elm.list(
+                        [
+                            self.decoder_expression_helper(de)
+                            for de in self.decoder_expressions
+                        ]
+                    )
+                ],
+            ),
+            None,
+        )
+
+    def decoder_expression_helper(
+        self,
+        variant: tuple[str, Compiler.Expression],
+    ) -> Compiler.Expression:
+        variant_name = variant[0]
+        variant_decoder_expression = variant[1]
+
+        return Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "map", None, None),
+            [Elm.value(variant_name), variant_decoder_expression],
+        )
 
 
 ObjHelperReturn = typing.TypedDict(
@@ -241,6 +441,7 @@ ObjHelperReturn = typing.TypedDict(
         "elm_values": PreparedElm,
         "alias_extra": str,
         "decoder_extra": str,
+        "field_annotations": list[tuple[str, Compiler.Annotation]],
     },
 )
 SingleHelperReturn = typing.TypedDict(
@@ -250,6 +451,8 @@ SingleHelperReturn = typing.TypedDict(
         "anno": PrimitiveObjectFlagType,
         "elm_values": PreparedElm,
         "alias_extra": str,
+        "compiler_annotation": Compiler.Annotation,
+        "decoder_expression": Compiler.Expression,
         "decoder_extra": str,
     },
 )
@@ -265,18 +468,32 @@ class BaseFlag(metaclass=FlagMetaClass):
         assert isinstance(d, Flag)
 
         prepared_flags: ObjHelperReturn | SingleHelperReturn | None = None
+        decoder_sig = (
+            Compiler.Signature(
+                "toModel",
+                Compiler.Typed("Decode.Decoder", [Compiler.Typed("ToModel", [])]),
+            ),
+            Elm.apply(
+                Exp.FunctionOrValue(
+                    Module.ModuleName(["Decode"]), "succeed", None, None
+                ),
+                [
+                    Elm.value("ToModel"),
+                ],
+            ),
+        )
 
         match d:
             case ObjectFlag(obj=_):
-                prepared_flags = _prepare_pipeline_flags(d, "Decode.succeed ToModel")
+                prepared_flags = _prepare_pipeline_flags(d, decoder_sig)
             case ModelChoiceFieldFlag() as mcf:
                 prepared_flags = _prepare_pipeline_flags(
-                    mcf.obj(), "Decode.succeed ToModel"
+                    mcf.obj(), decoder_sig=decoder_sig
                 )
                 prepared_flags["adapter"] = ModelChoiceFieldAdapter
             case _:
                 prepared_flags = _prepare_inline_flags(
-                    d, ObjectDecoder("inlineToModel", 1)
+                    d, ObjectDecoder("inlineToModel", 1), decoder_sig=decoder_sig
                 )
 
         assert prepared_flags is not None
@@ -318,7 +535,10 @@ class BaseFlag(metaclass=FlagMetaClass):
 
 
 def _prepare_inline_flags(
-    d: Flag, object_decoder: ObjectDecoder | None = None, depth: int = 1
+    d: Flag,
+    object_decoder: ObjectDecoder | None = None,
+    depth: int = 1,
+    decoder_sig: tuple[Compiler.Signature, Compiler.Expression] | None = None,
 ) -> SingleHelperReturn:
     adapter: TypeAdapter
     anno: PrimitiveObjectFlagType
@@ -326,51 +546,128 @@ def _prepare_inline_flags(
     decoder_body = ""
     decoder_extra: str = ""
     alias_extra: str = ""
+    compiler_annotation = None
+    decoder_expression: Compiler.Expression | None = None
     match d:
         case StringFlag():
             adapter = StringAdapter
             anno = annotated_string  # type:ignore
-            alias_type = StringDecoder._raw_type()
+            alias_type = StringDecoder._annotation()
             decoder_body = StringDecoder._raw_decoder()
+            compiler_annotation = StringDecoder._compiler_annotation()
+            decoder_expression = StringDecoder.decoder_expression()
         case IntFlag():
             adapter = IntAdapter
             anno = annotated_int  # type:ignore
-            alias_type = IntDecoder._raw_type()
+            alias_type = IntDecoder._annotation()
             decoder_body = IntDecoder._raw_decoder()
+            compiler_annotation = IntDecoder._compiler_annotation()
+            decoder_expression = IntDecoder.decoder_expression()
         case FloatFlag():
             adapter = FloatAdapter
             anno = annotated_float  # type:ignore
-            alias_type = FloatDecoder._raw_type()
+            alias_type = FloatDecoder._annotation()
             decoder_body = FloatDecoder._raw_decoder()
+            compiler_annotation = FloatDecoder._compiler_annotation()
+            decoder_expression = FloatDecoder.decoder_expression()
         case BoolFlag():
             adapter = BoolAdapter
             anno = annotated_bool  # type:ignore
-            alias_type = BoolDecoder._raw_type()
+            alias_type = BoolDecoder._annotation()
             decoder_body = BoolDecoder._raw_decoder()
+            compiler_annotation = BoolDecoder._compiler_annotation()
+            decoder_expression = BoolDecoder.decoder_expression()
         case NullableFlag(obj=obj):
             single_flag = _prepare_inline_flags(obj, object_decoder)
             t = single_flag["anno"]
             adapter = TypeAdapter(Annotated[typing.Optional[t], None])
             anno = typing.Optional[t]  # type:ignore
-            alias_type = NullableDecoder._raw_type(
-                single_flag["elm_values"]["alias_type"]
-            )
+            alias_type = NullableDecoder._annotation(single_flag["compiler_annotation"])
             alias_extra += single_flag["alias_extra"]
             decoder_body = NullableDecoder._raw_decoder(
                 single_flag["elm_values"]["decoder_body"]
             )
             decoder_extra += single_flag["decoder_extra"]
+            compiler_annotation = NullableDecoder._compiler_annotation(
+                single_flag["compiler_annotation"]
+            )
+            decoder_expression = NullableDecoder.decoder_expression(
+                single_flag["decoder_expression"]
+            )
         case ListFlag(obj=obj):
             single_flag = _prepare_inline_flags(obj, object_decoder)
             t = single_flag["anno"]
             adapter = TypeAdapter(Annotated[list[t], None])  # type:ignore
             anno = list[t]  # type:ignore
-            alias_type = ListDecoder._raw_type(single_flag["elm_values"]["alias_type"])
+            alias_type = ListDecoder._annotation(single_flag["compiler_annotation"])
             alias_extra += single_flag["alias_extra"]
             decoder_body = ListDecoder._raw_decoder(
                 single_flag["elm_values"]["decoder_body"]
             )
             decoder_extra += single_flag["decoder_extra"]
+            compiler_annotation = ListDecoder._compiler_annotation(
+                single_flag["compiler_annotation"]
+            )
+            decoder_expression = ListDecoder.decoder_expression(
+                single_flag["decoder_expression"]
+            )
+        case CustomTypeFlag(variants=v):
+            if object_decoder is None:
+                raise Exception(
+                    "Missing an ObjectDecoder argument for CustomTypeDecoder"
+                )
+            assert 0 < len(v)
+
+            annos = []
+            alias_extras: list[str] = []
+            decoder_extras: list[str] = []
+            variants: list[Compiler.Variant] = []
+            next_object_decoder = ObjectDecoder(
+                object_decoder.value, object_decoder.depth + 1
+            )
+            variant_decoder_expressions: list[tuple[str, Compiler.Expression]] = []
+            for var in v:
+                formatted_constructor = Format.safe_capitalize(var[0])
+                next_object_decoder = ObjectDecoder(
+                    formatted_constructor,
+                    object_decoder.depth + 1,
+                    object_decoder._to_annotation(),
+                )
+                prepared = _prepare_inline_flags(var[1], next_object_decoder)
+                variant_decoder_expressions.append(
+                    (formatted_constructor, prepared["decoder_expression"])
+                )
+                annos.append(prepared["anno"])
+                alias_extras.append(prepared["alias_extra"])
+                decoder_extras.append(prepared["decoder_extra"])
+                if prepared["compiler_annotation"]:
+                    variants.append(
+                        (
+                            Elm.variantWith(
+                                formatted_constructor, [prepared["compiler_annotation"]]
+                            )
+                        )
+                    )
+
+            adapter = TypeAdapter(typing.Union[*annos])  # type:ignore
+            anno = typing.Union[*annos]  # type:ignore
+
+            custom_type_decoder = CustomTypeDecoder(
+                object_decoder._to_annotation(),
+                depth,
+                variants,
+                variant_decoder_expressions,
+            )
+
+            compiler_annotation = custom_type_decoder._compiler_annotation()
+
+            # decoder_body = object_decoder._to_decoder_name()
+            decoder_extra = "".join(decoder_extras)
+            alias_type = custom_type_decoder._to_annotation()
+            alias_extra = "".join(
+                ["\n\n" + custom_type_decoder._to_declaration(), *alias_extras]
+            )
+            decoder_expression = custom_type_decoder.decoder_expression()
         case ModelChoiceFieldFlag() as mcf:
             if object_decoder is None:
                 raise Exception(f"Missing an ObjectDecoder argument for {mcf.obj()}")
@@ -384,25 +681,38 @@ def _prepare_inline_flags(
 
             Subsequent alias's will have their parent added to the start. i.e. type alias InlineToModel_A__
             """
-            if object_decoder._to_alias() != "InlineToModel_":
-                parent_key = object_decoder._to_alias()
+            if object_decoder._to_annotation() != "InlineToModel_":
+                parent_key = object_decoder._to_annotation()
 
             object_flag = _prepare_pipeline_flags(
                 mcf.obj(),
-                object_decoder.pipeline_starter(),
+                (
+                    object_decoder.pipeline_signature(),
+                    object_decoder.pipeline_starter_expression(),
+                ),
                 depth + 1,
                 parent_key,
             )
             adapter = ModelChoiceFieldAdapter
             # Use internal annotation
             anno = mcf.anno()
+            declaration = Elm.alias(
+                object_decoder._to_annotation(),
+                Anno.record(object_flag["field_annotations"]),
+            )
+            compiler_annotation = object_decoder._compiler_annotation(
+                Anno.record(object_flag["field_annotations"])
+            )
 
-            alias_type = object_decoder._to_alias()
-            alias_extra = object_decoder._to_alias_definition(
-                object_flag["elm_values"]["alias_type"]
+            alias_type = object_decoder._to_annotation()
+            alias_extra = (
+                "\n\n"
+                + Writer.writeDeclartion(declaration).write()
+                + object_flag["alias_extra"]
             )
             decoder_body = object_decoder._to_decoder_name()
             decoder_extra = f"\n\n{object_flag['elm_values']['decoder_body']}"
+            decoder_expression = object_decoder.decoder_expression()
         case ObjectFlag(obj=obj):
             if object_decoder is None:
                 raise Exception(f"Missing an ObjectDecoder argument for {obj}")
@@ -416,26 +726,47 @@ def _prepare_inline_flags(
 
             Subsequent alias's will have their parent added to the start. i.e. type alias InlineToModel_A__
             """
-            if object_decoder._to_alias() != "InlineToModel_":
-                parent_key = object_decoder._to_alias()
+            if object_decoder._to_annotation() != "InlineToModel_":
+                parent_key = object_decoder._to_annotation()
             object_flag = _prepare_pipeline_flags(
                 d,
-                object_decoder.pipeline_starter(),
+                (
+                    object_decoder.pipeline_signature(),
+                    object_decoder.pipeline_starter_expression(),
+                ),
                 depth + 1,
                 parent_key,
             )
             t = object_flag["anno"]  # type:ignore
+            declaration = Elm.alias(
+                object_decoder._to_annotation(),
+                Anno.record(object_flag["field_annotations"]),
+            )
+            compiler_annotation = object_decoder._compiler_annotation(
+                Anno.record(object_flag["field_annotations"])
+            )
 
             adapter = object_flag["adapter"]
             anno = t  # type:ignore
-            alias_type = object_decoder._to_alias()
-            alias_extra = object_decoder._to_alias_definition(
-                object_flag["elm_values"]["alias_type"]
+
+            alias_type = Anno.toString(compiler_annotation)
+            alias_extra = (
+                "\n\n"
+                + Writer.writeDeclartion(declaration).write()
+                + object_flag["alias_extra"]
             )
             decoder_body = object_decoder._to_decoder_name()
             decoder_extra = f"\n\n{object_flag['elm_values']['decoder_body']}"
+            decoder_expression = object_decoder.decoder_expression()
         case _:
             raise Exception(f"Can't resolve core_schema type for: {d}")
+
+    if decoder_sig:
+        sig, _ = decoder_sig
+        decoder_body = Writer.writeDeclartion(
+            Elm.declaration(sig.name, decoder_expression, sig)
+        ).write()
+
     return {
         "adapter": adapter,
         "anno": anno,
@@ -444,18 +775,24 @@ def _prepare_inline_flags(
             "decoder_body": decoder_body,
         },
         "alias_extra": alias_extra,
+        "compiler_annotation": compiler_annotation,
+        "decoder_expression": decoder_expression,
         "decoder_extra": decoder_extra,
     }
 
 
 def _prepare_pipeline_flags(
-    d: Flag, decoder_start: str, depth: int = 1, parent_key: str | None = None
+    d: Flag,
+    decoder_sig: tuple[Compiler.Signature, Compiler.Expression],
+    depth: int = 1,
+    parent_key: str | None = None,
 ) -> ObjHelperReturn:
     anno: typing.Dict[str, PrimitiveObjectFlagType] = {}
-    pipeline_decoder: str = decoder_start
     alias_values: str = ""
     decoder_extra: str = ""
     alias_extra: str = ""
+    field_annotations: list[tuple[str, Compiler.Annotation]] = []
+    pipeline_expressions: list[Compiler.Expression] = []
 
     assert isinstance(d, ObjectFlag)
 
@@ -469,20 +806,40 @@ def _prepare_pipeline_flags(
                     prepared_object_recursive = _prepare_pipeline_flags(
                         # Use built in flags
                         mcf.obj(),
-                        decoder.pipeline_starter(),
+                        (
+                            decoder.pipeline_signature(),
+                            decoder.pipeline_starter_expression(),
+                        ),
                         depth + 1,
-                        decoder._to_alias(),
+                        parent_key=decoder._to_annotation(),
                     )
 
                     # Use built in annotations
                     anno[k] = mcf.anno()
+                    declaration = Elm.alias(
+                        decoder._to_annotation(),
+                        Anno.record(prepared_object_recursive["field_annotations"]),
+                    )
+                    field_annotations.append(
+                        (
+                            k,
+                            Anno.alias(
+                                decoder._to_annotation(),
+                                Anno.record(
+                                    prepared_object_recursive["field_annotations"]
+                                ),
+                            ),
+                        )
+                    )
                     decoder_extra += (
                         f"\n\n{prepared_object_recursive['elm_values']['decoder_body']}"
                     )
-                    alias_extra += decoder._to_alias_definition(
-                        prepared_object_recursive["elm_values"]["alias_type"]
+                    alias_extra += (
+                        "\n\n"
+                        + Writer.writeDeclartion(declaration).write()
+                        + prepared_object_recursive["alias_extra"]
                     )
-                    pipeline_decoder += f"""\n        {decoder.pipeline()}"""
+                    pipeline_expressions.append(decoder.pipeline_expression())
                     if idx == 0:
                         alias_values += f" {decoder.alias()}"
                     else:
@@ -492,9 +849,12 @@ def _prepare_pipeline_flags(
                     decoder = ObjectDecoder(k, depth, parent_key)
                     prepared_object_recursive = _prepare_pipeline_flags(
                         ObjectFlag(obj),
-                        decoder.pipeline_starter(),
+                        (
+                            decoder.pipeline_signature(),
+                            decoder.pipeline_starter_expression(),
+                        ),
                         depth + 1,
-                        decoder._to_alias(),
+                        parent_key=decoder._to_annotation(),
                     )
                     anno[k] = type(
                         "K",
@@ -505,14 +865,31 @@ def _prepare_pipeline_flags(
                             ].__origin__.__annotations__  # type:ignore
                         },
                     )
+                    declaration = Elm.alias(
+                        decoder._to_annotation(),
+                        Anno.record(prepared_object_recursive["field_annotations"]),
+                    )
+                    field_annotations.append(
+                        (
+                            k,
+                            Anno.alias(
+                                decoder._to_annotation(),
+                                Anno.record(
+                                    prepared_object_recursive["field_annotations"]
+                                ),
+                            ),
+                        )
+                    )
 
                     decoder_extra += (
                         f"\n\n{prepared_object_recursive['elm_values']['decoder_body']}"
                     )
-                    alias_extra += decoder._to_alias_definition(
-                        prepared_object_recursive["elm_values"]["alias_type"]
+                    alias_extra += (
+                        "\n\n"
+                        + Writer.writeDeclartion(declaration).write()
+                        + prepared_object_recursive["alias_extra"]
                     )
-                    pipeline_decoder += f"""\n        {decoder.pipeline()}"""
+                    pipeline_expressions.append(decoder.pipeline_expression())
                     if idx == 0:
                         alias_values += f" {decoder.alias()}"
                     else:
@@ -524,18 +901,40 @@ def _prepare_pipeline_flags(
                     list_decoder = ListDecoder(
                         k,
                         single_flag["elm_values"]["decoder_body"],
-                        single_flag["elm_values"]["alias_type"],
+                        single_flag["compiler_annotation"],
                     )
                     alias_extra += single_flag["alias_extra"]
                     decoder_extra += single_flag["decoder_extra"]
                     anno[k] = list[single_flag["anno"]]  # type:ignore
-
-                    pipeline_decoder += f"""\n        {list_decoder.pipeline()}"""
-
+                    field_annotations.append(
+                        (k, Anno.list(single_flag["compiler_annotation"]))
+                    )
+                    pipeline_expressions.append(list_decoder.pipeline_expression())
                     if idx == 0:
                         alias_values += f" {list_decoder.alias()}"
                     else:
                         alias_values += f"\n    {list_decoder.nested_alias()}"
+
+                case CustomTypeFlag(variants=_) as ctf:
+                    decoder = ObjectDecoder(k, depth, parent_key)
+                    single_flag = _prepare_inline_flags(ctf, decoder)
+                    anno[k] = typing.Optional[single_flag["anno"]]  # type:ignore
+                    field_annotations.append((k, single_flag["compiler_annotation"]))
+
+                    alias_extra += single_flag["alias_extra"]
+                    decoder_extra += single_flag["decoder_extra"]
+
+                    pipeline_expressions.append(
+                        CustomTypeDecoder.pipeline_expression(
+                            k, single_flag["decoder_expression"]
+                        )
+                    )
+                    if idx == 0:
+                        alias_values += f" {decoder.alias()}"
+                    else:
+                        alias_values += f"\n    {decoder.nested_alias()}"
+                    pass
+
                 case NullableFlag(obj=obj1):
                     single_flag = _prepare_inline_flags(
                         obj1, ObjectDecoder(k, depth, parent_key)
@@ -543,61 +942,92 @@ def _prepare_pipeline_flags(
                     nullable_decoder = NullableDecoder(
                         k,
                         single_flag["elm_values"]["decoder_body"],
-                        single_flag["elm_values"]["alias_type"],
+                        single_flag["compiler_annotation"],
                     )
                     alias_extra += single_flag["alias_extra"]
                     decoder_extra += single_flag["decoder_extra"]
                     anno[k] = typing.Optional[single_flag["anno"]]  # type:ignore
+                    field_annotations.append(
+                        (k, Anno.maybe(single_flag["compiler_annotation"]))
+                    )
 
-                    pipeline_decoder += f"""\n        {nullable_decoder.pipeline()}"""
+                    pipeline_expressions.append(nullable_decoder.pipeline_expression())
 
                     if idx == 0:
                         alias_values += f" {nullable_decoder.alias()}"
                     else:
                         alias_values += f"\n    {nullable_decoder.nested_alias()}"
                 case StringFlag():
+                    string_decoder = StringDecoder(k)
                     single_prepared = _prepare_inline_flags(v)
                     anno[k] = single_prepared["anno"]
-                    pipeline_decoder += f"""\n        {StringDecoder(k).pipeline()}"""
+                    field_annotations.append(
+                        (k, single_prepared["compiler_annotation"])
+                    )
+
+                    pipeline_expressions.append(string_decoder.pipeline_expression())
 
                     if idx == 0:
-                        alias_values += f" {StringDecoder(k).alias()}"
+                        alias_values += f" {string_decoder.alias()}"
                     else:
-                        alias_values += f"\n    {StringDecoder(k).nested_alias()}"
+                        alias_values += f"\n    {string_decoder.nested_alias()}"
 
                 case IntFlag():
+                    int_decoder = IntDecoder(k)
                     single_prepared = _prepare_inline_flags(v)
                     anno[k] = single_prepared["anno"]
-                    pipeline_decoder += f"""\n        {IntDecoder(k).pipeline()}"""
+                    field_annotations.append(
+                        (k, single_prepared["compiler_annotation"])
+                    )
+                    pipeline_expressions.append(int_decoder.pipeline_expression())
 
                     if idx == 0:
-                        alias_values += f" {IntDecoder(k).alias()}"
+                        alias_values += f" {int_decoder.alias()}"
                     else:
-                        alias_values += f"\n    {IntDecoder(k).nested_alias()}"
+                        alias_values += f"\n    {int_decoder.nested_alias()}"
 
                 case FloatFlag():
+                    float_decoder = FloatDecoder(k)
                     single_prepared = _prepare_inline_flags(v)
                     anno[k] = single_prepared["anno"]
-                    pipeline_decoder += f"""\n        {FloatDecoder(k).pipeline()}"""
+                    field_annotations.append(
+                        (k, single_prepared["compiler_annotation"])
+                    )
+                    pipeline_expressions.append(float_decoder.pipeline_expression())
 
                     if idx == 0:
-                        alias_values += f" {FloatDecoder(k).alias()}"
+                        alias_values += f" {float_decoder.alias()}"
                     else:
-                        alias_values += f"\n    {FloatDecoder(k).nested_alias()}"
+                        alias_values += f"\n    {float_decoder.nested_alias()}"
 
                 case BoolFlag():
+                    bool_decoder = BoolDecoder(k)
                     single_prepared = _prepare_inline_flags(v)
                     anno[k] = single_prepared["anno"]
-                    pipeline_decoder += f"""\n        {BoolDecoder(k).pipeline()}"""
+                    field_annotations.append(
+                        (k, single_prepared["compiler_annotation"])
+                    )
+                    pipeline_expressions.append(bool_decoder.pipeline_expression())
                     if idx == 0:
-                        alias_values += f" {BoolDecoder(k).alias()}"
+                        alias_values += f" {bool_decoder.alias()}"
                     else:
-                        alias_values += f"\n    {BoolDecoder(k).nested_alias()}"
+                        alias_values += f"\n    {bool_decoder.nested_alias()}"
 
                 case _:
                     raise Exception("Unsopported type")
         except Exception as err:
             raise err
+
+    sig, top_pipe = decoder_sig
+
+    pipeline_decoder = Writer.writeDeclartion(
+        Elm.declaration(
+            sig.name,
+            Op.pipes(top_pipe, reversed(pipeline_expressions)),
+            sig,
+        )
+    ).write()
+
     return {
         "adapter": TypeAdapter(
             Annotated[type("K", (BaseModel,), {"__annotations__": anno}), None]
@@ -609,6 +1039,7 @@ def _prepare_pipeline_flags(
         },
         "alias_extra": alias_extra,
         "decoder_extra": decoder_extra,
+        "field_annotations": field_annotations,
     }
 
 

--- a/src/djelm/flags/primitives.py
+++ b/src/djelm/flags/primitives.py
@@ -49,6 +49,32 @@ class ObjectFlag(Flag):
     obj: typing.Dict[str, Flag]
 
 
+@dataclass(slots=True)
+class CustomTypeFlag(Flag):
+    """
+    A Flag for an Elm custom type.
+
+    <https://guide.elm-lang.org/types/custom_types>
+
+    variants = A list of tuples that specify the a discriminator and flag.
+
+    i.e.
+            FlagModel = Flags(CustomTypeFlag(variants=[("Custom1",StringFLag()), ("Custom2",IntFlag())]))
+
+            Turns into the the Elm type:
+
+            type SomeCustomType
+                = Custom1 String
+                | Custom2 Int
+
+            Then we parse a valid data structure:
+
+            FlagModel.parse("Hi there")
+    """
+
+    variants: list[tuple[str, Flag]]
+
+
 FlagsObject = dict[str, "PrimitiveFlag"]
 FlagsList = list["PrimitiveFlag"]
 FlagsNullable = typing.Union[type[str], type[int], type[float], type[bool], type[None]]

--- a/src/djelm/model_template/{{cookiecutter.tmp_dir}}/{{cookiecutter.program_name}}.elmf
+++ b/src/djelm/model_template/{{cookiecutter.tmp_dir}}/{{cookiecutter.program_name}}.elmf
@@ -12,6 +12,4 @@ type alias ToModel =
     {{cookiecutter.alias_type}}
 
 
-toModel : Decode.Decoder ToModel
-toModel =
-    {{cookiecutter.decoder_body}}
+{{cookiecutter.decoder_body}}

--- a/tests/codegen/test_annotation.py
+++ b/tests/codegen/test_annotation.py
@@ -1,0 +1,86 @@
+import djelm.codegen.annotation as Anno
+
+
+class TestToString:
+    def test_with_string(self):
+        anno = Anno.string()
+        SUT = Anno.toString(anno)
+
+        assert SUT == "String"
+
+    def test_with_int(self):
+        anno = Anno.int()
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Int"
+
+    def test_with_float(self):
+        anno = Anno.float()
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Float"
+
+    def test_with_bool(self):
+        anno = Anno.bool()
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Bool"
+
+    def test_with_maybe_string(self):
+        anno = Anno.maybe(Anno.string())
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Maybe String"
+
+    def test_with_maybe_int(self):
+        anno = Anno.maybe(Anno.int())
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Maybe Int"
+
+    def test_with_maybe_float(self):
+        anno = Anno.maybe(Anno.float())
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Maybe Float"
+
+    def test_with_maybe_bool(self):
+        anno = Anno.maybe(Anno.bool())
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Maybe Bool"
+
+    def test_with_maybe_list_string(self):
+        anno = Anno.maybe(Anno.list(Anno.string()))
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Maybe (List String)"
+
+    def test_with_list_string(self):
+        anno = Anno.list(Anno.string())
+        SUT = Anno.toString(anno)
+
+        assert SUT == "List String"
+
+    def test_with_alias(self):
+        anno = Anno.alias("Something", Anno.string())
+        SUT = Anno.toString(anno)
+
+        assert SUT == "Something"
+
+    def test_with_record_fields(self):
+        anno = Anno.record([("hello", Anno.string()), ("world", Anno.string())])
+        SUT = Anno.toString(anno)
+
+        assert (
+            SUT
+            == """{ hello : String
+, world : String
+}"""
+        )
+
+    def test_with_record_field(self):
+        anno = Anno.record([("hello", Anno.string())])
+        SUT = Anno.toString(anno)
+
+        assert SUT == """{ hello : String }"""

--- a/tests/codegen/test_declaration.py
+++ b/tests/codegen/test_declaration.py
@@ -1,0 +1,178 @@
+import djelm.codegen.elm as Elm
+import djelm.codegen.annotation as Anno
+import djelm.codegen.writer as Writer
+import djelm.codegen.op as Op
+import djelm.codegen.expression as Exp
+import djelm.codegen.module_name as Module
+import djelm.codegen.range as Range
+import djelm.codegen.compiler as Compiler
+
+
+class TestExpressions:
+    def test_alias_declaration(self):
+        decl = Elm.alias(
+            "Something",
+            Anno.record([("hello", Anno.string()), ("world", Anno.string())]),
+        )
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type alias Something =
+    { hello : String
+    , world : String
+    }"""
+        )
+
+    def test_alias_declaration_with_lower(self):
+        decl = Elm.alias(
+            "something",
+            Anno.record([("hello", Anno.string()), ("world", Anno.string())]),
+        )
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type alias Something =
+    { hello : String
+    , world : String
+    }"""
+        )
+
+    def test_custom_type_declaration(self):
+        decl = Elm.customType("Something", [Elm.variant("Hello"), Elm.variant("World")])
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type Something
+    = Hello
+    | World
+"""
+        )
+
+    def test_custom_type_single_string_variant(self):
+        decl = Elm.customType("Something", [Elm.variant("A"), Elm.variant("B")])
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type Something
+    = A
+    | B
+"""
+        )
+
+    def test_custom_type_single_string_lowercase_variant(self):
+        decl = Elm.customType("Something", [Elm.variant("aa"), Elm.variant("bb")])
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type Something
+    = Aa
+    | Bb
+"""
+        )
+
+    def test_custom_type_declaration_with_lower(self):
+        decl = Elm.customType("something", [Elm.variant("Hello"), Elm.variant("World")])
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type Something
+    = Hello
+    | World
+"""
+        )
+
+    def test_custom_type_declaration_with_annotated_variants(self):
+        decl = Elm.customType(
+            "Something",
+            [
+                Elm.variantWith("Hello", [Anno.string()]),
+                Elm.variantWith("World", [Anno.maybe(Anno.string())]),
+                Elm.variantWith("Is", [Anno.maybe(Anno.list(Anno.string()))]),
+                Elm.variantWith(
+                    "Classic",
+                    [
+                        Anno.alias(
+                            "AnAlias", Anno.record([("something", Anno.string())])
+                        )
+                    ],
+                ),
+            ],
+        )
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """type Something
+    = Hello String
+    | World (Maybe String)
+    | Is (Maybe (List String))
+    | Classic AnAlias
+"""
+        )
+
+    def test_declaration_with_pipe_operator_expression(self):
+        sig = Compiler.Signature(
+            "options_Decoder",
+            Compiler.Typed("Decode.Decoder", [Compiler.Typed("ToModel", [])]),
+        )
+        pipe = Op.pipe(
+            Elm.apply(
+                Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+                [
+                    Elm.literal("someField01"),
+                    Elm.apply(
+                        Exp.FunctionOrValue(
+                            Module.ModuleName(["Decode"]), "int", None, None
+                        ),
+                        [],
+                    ),
+                ],
+                Range.Range(1, 0),
+            ),
+            Op.pipe(
+                Elm.apply(
+                    Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+                    [
+                        Elm.literal("someField"),
+                        Exp.Application(
+                            [
+                                Exp.FunctionOrValue(
+                                    Module.ModuleName(["Decode"]),
+                                    "string",
+                                    None,
+                                    None,
+                                )
+                            ],
+                            None,
+                            None,
+                        ),
+                    ],
+                    Range.Range(1, 0),
+                ),
+                Elm.apply(
+                    Exp.FunctionOrValue(
+                        Module.ModuleName(["Decode"]), "succeed", None, None
+                    ),
+                    [
+                        Elm.value("ToModel"),
+                    ],
+                ),
+            ),
+        )
+        decl = Elm.declaration("options_Decoder", pipe, sig)
+        SUT = Writer.writeDeclartion(decl)
+
+        assert (
+            SUT.write()
+            == """options_Decoder : Decode.Decoder ToModel
+options_Decoder =
+    Decode.succeed ToModel
+        |> required \"someField\" Decode.string
+        |> required \"someField01\" Decode.int"""
+        )

--- a/tests/codegen/test_expression.py
+++ b/tests/codegen/test_expression.py
@@ -1,0 +1,151 @@
+import djelm.codegen.expression as Exp
+import djelm.codegen.elm as Elm
+import djelm.codegen.writer as Writer
+import djelm.codegen.range as Range
+import djelm.codegen.module_name as Module
+import djelm.codegen.op as Op
+
+
+class TestExpressions:
+    def test_pipe(self):
+        SUT = Writer.writeExpression(
+            Op.pipe(
+                Elm.apply(
+                    Exp.FunctionOrValue(Module.ModuleName([]), "required", None, None),
+                    [
+                        Exp.Literal("someField01", None),
+                        Exp.Parenthesized(
+                            Elm.apply(
+                                Exp.FunctionOrValue(
+                                    Module.ModuleName(["Decode"]),
+                                    "nullable",
+                                    None,
+                                    None,
+                                ),
+                                [Elm.value("Decode.string")],
+                            ),
+                            None,
+                        ),
+                    ],
+                    Range.Range(1, 0),
+                ),
+                Op.pipe(
+                    Elm.apply(
+                        Exp.FunctionOrValue(
+                            Module.ModuleName([]), "required", None, None
+                        ),
+                        [
+                            Exp.Literal("someField", None),
+                            Exp.Application(
+                                [
+                                    Exp.FunctionOrValue(
+                                        Module.ModuleName(["Decode"]),
+                                        "string",
+                                        None,
+                                        None,
+                                    )
+                                ],
+                                None,
+                                None,
+                            ),
+                        ],
+                        Range.Range(1, 0),
+                    ),
+                    Elm.apply(
+                        Exp.FunctionOrValue(
+                            Module.ModuleName(["Decode"]), "succeed", None, None
+                        ),
+                        [
+                            Elm.value("ToModel"),
+                        ],
+                    ),
+                ),
+            ),
+        )
+        assert (
+                SUT.write()
+                == """Decode.succeed ToModel
+    |> required \"someField\" Decode.string
+    |> required \"someField01\" (Decode.nullable Decode.string)"""
+        )
+
+    def test_pipes(self):
+        top_pipe = Elm.apply(
+            Exp.FunctionOrValue(Module.ModuleName(["Decode"]), "succeed", None, None),
+            [
+                Elm.value("ToModel"),
+            ],
+        )
+        SUT = Writer.writeExpression(
+            Op.pipes(
+                top_pipe,
+                iter(
+                    [
+                        Elm.apply(
+                            Exp.FunctionOrValue(
+                                Module.ModuleName([]), "required", None, None
+                            ),
+                            [
+                                Exp.Literal("someField01", None),
+                                Exp.Parenthesized(
+                                    Elm.apply(
+                                        Exp.FunctionOrValue(
+                                            Module.ModuleName(["Decode"]),
+                                            "nullable",
+                                            None,
+                                            None,
+                                        ),
+                                        [Elm.value("Decode.string")],
+                                    ),
+                                    None,
+                                ),
+                            ],
+                            Range.Range(1, 0),
+                        ),
+                        Elm.apply(
+                            Exp.FunctionOrValue(
+                                Module.ModuleName([]), "required", None, None
+                            ),
+                            [
+                                Exp.Literal("someField", None),
+                                Exp.Parenthesized(
+                                    Elm.apply(
+                                        Exp.FunctionOrValue(
+                                            Module.ModuleName(["Decode"]),
+                                            "nullable",
+                                            None,
+                                            None,
+                                        ),
+                                        [Elm.value("Decode.string")],
+                                    ),
+                                    None,
+                                ),
+                            ],
+                            Range.Range(1, 0),
+                        ),
+                    ]
+                ),
+            )
+        )
+
+        assert (
+                SUT.write()
+                == """Decode.succeed ToModel
+    |> required \"someField\" (Decode.nullable Decode.string)
+    |> required \"someField01\" (Decode.nullable Decode.string)"""
+        )
+
+    def test_plus_expression(self):
+        SUT = Writer.writeExpression(
+            Op.plus(
+                Elm.int(2),
+                Elm.int(2),
+            )
+        )
+
+        assert SUT.write() == """2 + 2"""
+
+    def test_list_expression(self):
+        SUT = Writer.writeExpression(Elm.list([Elm.literal("someVar")]))
+
+        assert SUT.write() == "[\"someVar\"]"

--- a/tests/fuzz_flags.py
+++ b/tests/fuzz_flags.py
@@ -21,6 +21,8 @@ ALL_FLAGS = [
     IntFlag,
     FloatFlag,
     BoolFlag,
+    # TODO solve constructor name clashes
+    # CustomTypeFlag,
     # forms
     ModelChoiceFieldFlag,
 ]
@@ -51,5 +53,16 @@ def fuzz_flag():
 
     if choice is NullableFlag:
         return NullableFlag(fuzz_flag())
+
+    # TODO solve constructor name clashes
+    # if choice is CustomTypeFlag:
+    #     variant_keys = generate_alias_keys()
+    #     variants = []
+    #
+    #     for k in variant_keys:
+    #         k = k.replace("\n", "")
+    #         variants.append((k, fuzz_flag()))
+    #
+    #     return CustomTypeFlag(variants=variants)
 
     return choice()

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -9,6 +9,7 @@ from djelm.elm import Elm
 from djelm.flags.form.primitives import ModelChoiceFieldFlag
 from djelm.flags.primitives import (
     BoolFlag,
+    CustomTypeFlag,
     FloatFlag,
     IntFlag,
     ListFlag,
@@ -109,7 +110,7 @@ def test_fuzz_flags():
 
     programs = []
 
-    for i in range(1, 12):
+    for i in range(1, 13):
         flags = fuzz_flag()
 
         class MockHandler(ModelGenerator):
@@ -178,26 +179,26 @@ class TestFuzzExamplesGenerated:
     }
 
 type alias Yh_ =
-    { dFE3 : Maybe (Maybe Yh_DFE3__)
-    }
+    { dFE3 : Maybe (Maybe Yh_DFE3__) }
 
 type alias Yh_DFE3__ =
-    { k69xy : Maybe (Maybe Int)
-    }"""
+    { k69xy : Maybe (Maybe Int) }"""
         )
         assert SUT.to_elm_parser_data()["decoder_body"] == (
-            """Decode.succeed ToModel
-        |>  required "yh" yh_Decoder
+            """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "yh" yh_Decoder
 
 yh_Decoder : Decode.Decoder Yh_
 yh_Decoder =
     Decode.succeed Yh_
-        |>  required "dFE3" (Decode.nullable (Decode.nullable yh_dFE3__Decoder))
+        |> required "dFE3" (Decode.nullable (Decode.nullable yh_dFE3__Decoder))
 
 yh_dFE3__Decoder : Decode.Decoder Yh_DFE3__
 yh_dFE3__Decoder =
     Decode.succeed Yh_DFE3__
-        |>  required "k69xy" (Decode.nullable (Decode.nullable Decode.int))"""
+        |> required "k69xy" (Decode.nullable (Decode.nullable Decode.int))"""
         )
 
     def test_fuzz_failure_02(self):
@@ -217,15 +218,17 @@ yh_dFE3__Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data()["decoder_body"] == (
-            """Decode.succeed ToModel
-        |>  required "zJc" Decode.bool
-        |>  required "dEB" (Decode.list (Decode.list (Decode.nullable dEB_Decoder)))
-        |>  required "dKfU" (Decode.list (Decode.nullable Decode.bool))
+            """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "zJc" Decode.bool
+        |> required "dEB" (Decode.list (Decode.list (Decode.nullable dEB_Decoder)))
+        |> required "dKfU" (Decode.list (Decode.nullable Decode.bool))
 
 dEB_Decoder : Decode.Decoder DEB_
 dEB_Decoder =
     Decode.succeed DEB_
-        |>  required "z" (Decode.nullable (Decode.list Decode.bool))"""
+        |> required "z" (Decode.nullable (Decode.list Decode.bool))"""
         )
 
     def test_fuzz_failure_03(self):
@@ -248,47 +251,45 @@ dEB_Decoder =
     }
 
 type alias A_ =
-    { options : A_Options__
-    }
+    { options : A_Options__ }
 
 type alias A_Options__ =
-    { name : String
-    }
+    { name : String }
 
 type alias B_ =
-    { options : B_Options__
-    }
+    { options : B_Options__ }
 
 type alias B_Options__ =
-    { name : String
-    }"""
+    { name : String }"""
         )
 
         assert (
             SUT.to_elm_parser_data()["decoder_body"]
-            == """Decode.succeed ToModel
-        |>  required "a" a_Decoder
-        |>  required "b" (Decode.list b_Decoder)
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "a" a_Decoder
+        |> required "b" (Decode.list b_Decoder)
 
 a_Decoder : Decode.Decoder A_
 a_Decoder =
     Decode.succeed A_
-        |>  required "options" a_options__Decoder
+        |> required "options" a_options__Decoder
 
 a_options__Decoder : Decode.Decoder A_Options__
 a_options__Decoder =
     Decode.succeed A_Options__
-        |>  required "name" Decode.string
+        |> required "name" Decode.string
 
 b_Decoder : Decode.Decoder B_
 b_Decoder =
     Decode.succeed B_
-        |>  required "options" b_options__Decoder
+        |> required "options" b_options__Decoder
 
 b_options__Decoder : Decode.Decoder B_Options__
 b_options__Decoder =
     Decode.succeed B_Options__
-        |>  required "name" Decode.string"""
+        |> required "name" Decode.string"""
         )
 
 
@@ -313,7 +314,9 @@ class TestStringFlags:
 
         assert SUT.to_elm_parser_data() == {
             "alias_type": "String",
-            "decoder_body": "Decode.string",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.string""",
         }
 
     def test_with_object_to_elm_parser(self):
@@ -323,9 +326,11 @@ class TestStringFlags:
             "alias_type": """{ hello : String
     , world : String
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" Decode.string
-        |>  required "world" Decode.string""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" Decode.string
+        |> required "world" Decode.string""",
         }
 
 
@@ -350,7 +355,9 @@ class TestIntFlags:
 
         assert SUT.to_elm_parser_data() == {
             "alias_type": "Int",
-            "decoder_body": "Decode.int",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.int""",
         }
 
     def test_with_object_to_elm_parser(self):
@@ -360,9 +367,11 @@ class TestIntFlags:
             "alias_type": """{ hello : Int
     , world : Int
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" Decode.int
-        |>  required "world" Decode.int""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" Decode.int
+        |> required "world" Decode.int""",
         }
 
 
@@ -388,7 +397,9 @@ class TestFloatFlags:
 
         assert SUT.to_elm_parser_data() == {
             "alias_type": "Float",
-            "decoder_body": "Decode.float",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.float""",
         }
 
     def test_with_object_to_elm_parser(self):
@@ -398,9 +409,11 @@ class TestFloatFlags:
             "alias_type": """{ hello : Float
     , world : Float
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" Decode.float
-        |>  required "world" Decode.float""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" Decode.float
+        |> required "world" Decode.float""",
         }
 
 
@@ -503,8 +516,10 @@ class TestNullableFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe String)""",
-            "decoder_body": """(Decode.nullable Decode.string)""",
+            "alias_type": """Maybe String""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable Decode.string)""",
         }
 
     def test_with_int_to_elm_parser(self):
@@ -512,8 +527,10 @@ class TestNullableFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe Int)""",
-            "decoder_body": """(Decode.nullable Decode.int)""",
+            "alias_type": """Maybe Int""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable Decode.int)""",
         }
 
     def test_with_float_to_elm_parser(self):
@@ -521,8 +538,10 @@ class TestNullableFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe Float)""",
-            "decoder_body": """(Decode.nullable Decode.float)""",
+            "alias_type": """Maybe Float""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable Decode.float)""",
         }
 
     def test_with_bool_to_elm_parser(self):
@@ -530,8 +549,10 @@ class TestNullableFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe Bool)""",
-            "decoder_body": """(Decode.nullable Decode.bool)""",
+            "alias_type": """Maybe Bool""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable Decode.bool)""",
         }
 
     def test_with_list_with_string_to_elm_parser(self):
@@ -539,8 +560,10 @@ class TestNullableFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe (List String))""",
-            "decoder_body": """(Decode.nullable (Decode.list Decode.string))""",
+            "alias_type": """Maybe (List String)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable (Decode.list Decode.string))""",
         }
 
     def test_with_object_with_string_to_elm_parser(self):
@@ -548,45 +571,45 @@ class TestNullableFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe InlineToModel_)
+            "alias_type": """Maybe InlineToModel_
 
 type alias InlineToModel_ =
-    { hello : String
-    }""",
-            "decoder_body": """(Decode.nullable inlineToModel_Decoder)
+    { hello : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable inlineToModel_Decoder)
 
 inlineToModel_Decoder : Decode.Decoder InlineToModel_
 inlineToModel_Decoder =
     Decode.succeed InlineToModel_
-        |>  required "hello" Decode.string""",
+        |> required "hello" Decode.string""",
         }
 
     def test_with_object_with_object_to_elm_parser(self):
-        # TODO Fix this failing test
         d = NullableFlag(ObjectFlag({"hello": ObjectFlag({"world": StringFlag()})}))
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe InlineToModel_)
+            "alias_type": """Maybe InlineToModel_
 
 type alias InlineToModel_ =
-    { hello : Hello__
-    }
+    { hello : Hello__ }
 
 type alias Hello__ =
-    { world : String
-    }""",
-            "decoder_body": """(Decode.nullable inlineToModel_Decoder)
+    { world : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable inlineToModel_Decoder)
 
 inlineToModel_Decoder : Decode.Decoder InlineToModel_
 inlineToModel_Decoder =
     Decode.succeed InlineToModel_
-        |>  required "hello" hello__Decoder
+        |> required "hello" hello__Decoder
 
 hello__Decoder : Decode.Decoder Hello__
 hello__Decoder =
     Decode.succeed Hello__
-        |>  required "world" Decode.string""",
+        |> required "world" Decode.string""",
         }
 
     def test_with_nullable_with_string_to_elm_parser(self):
@@ -594,8 +617,10 @@ hello__Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe (Maybe String))""",
-            "decoder_body": """(Decode.nullable (Decode.nullable Decode.string))""",
+            "alias_type": """Maybe (Maybe String)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable (Decode.nullable Decode.string))""",
         }
 
     def test_with_nullable_with_int_to_elm_parser(self):
@@ -603,8 +628,10 @@ hello__Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe (Maybe Int))""",
-            "decoder_body": """(Decode.nullable (Decode.nullable Decode.int))""",
+            "alias_type": """Maybe (Maybe Int)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable (Decode.nullable Decode.int))""",
         }
 
     def test_with_nullable_with_bool_to_elm_parser(self):
@@ -612,8 +639,10 @@ hello__Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe (Maybe Bool))""",
-            "decoder_body": """(Decode.nullable (Decode.nullable Decode.bool))""",
+            "alias_type": """Maybe (Maybe Bool)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable (Decode.nullable Decode.bool))""",
         }
 
     def test_with_nullable_with_float_tol_elm_parser(self):
@@ -621,8 +650,10 @@ hello__Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe (Maybe Float))""",
-            "decoder_body": """(Decode.nullable (Decode.nullable Decode.float))""",
+            "alias_type": """Maybe (Maybe Float)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable (Decode.nullable Decode.float))""",
         }
 
     def test_with_nullable_with_list_to_elm_parser(self):
@@ -630,8 +661,10 @@ hello__Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(Maybe (Maybe (List String)))""",
-            "decoder_body": """(Decode.nullable (Decode.nullable (Decode.list Decode.string)))""",
+            "alias_type": """Maybe (Maybe (List String))""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.nullable (Decode.nullable (Decode.list Decode.string)))""",
         }
 
 
@@ -731,8 +764,10 @@ class TestListFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List String)""",
-            "decoder_body": """(Decode.list Decode.string)""",
+            "alias_type": """List String""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list Decode.string)""",
         }
 
     def test_with_int_to_elm_parser(self):
@@ -740,8 +775,10 @@ class TestListFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List Int)""",
-            "decoder_body": """(Decode.list Decode.int)""",
+            "alias_type": """List Int""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list Decode.int)""",
         }
 
     def test_with_float_to_elm_parser(self):
@@ -749,8 +786,10 @@ class TestListFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List Float)""",
-            "decoder_body": """(Decode.list Decode.float)""",
+            "alias_type": """List Float""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list Decode.float)""",
         }
 
     def test_with_bool_to_elm_parser(self):
@@ -758,8 +797,10 @@ class TestListFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List Bool)""",
-            "decoder_body": """(Decode.list Decode.bool)""",
+            "alias_type": """List Bool""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list Decode.bool)""",
         }
 
     def test_with_object_to_elm_parser(self):
@@ -767,17 +808,18 @@ class TestListFlags:
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List InlineToModel_)
+            "alias_type": """List InlineToModel_
 
 type alias InlineToModel_ =
-    { hello : String
-    }""",
-            "decoder_body": """(Decode.list inlineToModel_Decoder)
+    { hello : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list inlineToModel_Decoder)
 
 inlineToModel_Decoder : Decode.Decoder InlineToModel_
 inlineToModel_Decoder =
     Decode.succeed InlineToModel_
-        |>  required "hello" Decode.string""",
+        |> required "hello" Decode.string""",
         }
 
     def test_with_nullable_with_string_to_elm_parser(self):
@@ -785,8 +827,10 @@ inlineToModel_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List (Maybe String))""",
-            "decoder_body": """(Decode.list (Decode.nullable Decode.string))""",
+            "alias_type": """List (Maybe String)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list (Decode.nullable Decode.string))""",
         }
 
     def test_with_nullable_with_int_to_elm_parser(self):
@@ -794,8 +838,10 @@ inlineToModel_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List (Maybe Int))""",
-            "decoder_body": """(Decode.list (Decode.nullable Decode.int))""",
+            "alias_type": """List (Maybe Int)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list (Decode.nullable Decode.int))""",
         }
 
     def test_with_nullable_with_bool_to_elm_parser(self):
@@ -803,8 +849,10 @@ inlineToModel_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List (Maybe Bool))""",
-            "decoder_body": """(Decode.list (Decode.nullable Decode.bool))""",
+            "alias_type": """List (Maybe Bool)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list (Decode.nullable Decode.bool))""",
         }
 
     def test_with_nullable_with_float_to_elm_parser(self):
@@ -812,8 +860,10 @@ inlineToModel_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List (Maybe Float))""",
-            "decoder_body": """(Decode.list (Decode.nullable Decode.float))""",
+            "alias_type": """List (Maybe Float)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list (Decode.nullable Decode.float))""",
         }
 
     def test_with_nullable_with_list_to_elm_parser(self):
@@ -821,8 +871,10 @@ inlineToModel_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """(List (Maybe (List String)))""",
-            "decoder_body": """(Decode.list (Decode.nullable (Decode.list Decode.string)))""",
+            "alias_type": """List (Maybe (List String))""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.list (Decode.nullable (Decode.list Decode.string)))""",
         }
 
 
@@ -847,7 +899,9 @@ class TestBoolFlags:
 
         assert SUT.to_elm_parser_data() == {
             "alias_type": "Bool",
-            "decoder_body": "Decode.bool",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.bool""",
         }
 
     def test_with_object_with_bool_to_elm_parser(self):
@@ -857,9 +911,11 @@ class TestBoolFlags:
             "alias_type": """{ hello : Bool
     , world : Bool
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" Decode.bool
-        |>  required "world" Decode.bool""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" Decode.bool
+        |> required "world" Decode.bool""",
         }
 
 
@@ -1007,6 +1063,60 @@ class TestObjectFlags:
         with pytest.raises(ValidationError):
             SUT.parse({"hello": [22]})
 
+    def test_with_custom_type_with_string_flag_to_elm_parser(self):
+        d = ObjectFlag({"hello": CustomTypeFlag(variants=[("Custom1", StringFlag())])})
+        SUT = Flags(d)
+
+        assert SUT.to_elm_parser_data()["alias_type"] == (
+            """{ hello : Hello_
+    }
+
+type Hello_
+    = Custom1 String
+"""
+        )
+
+    def test_with_custom_type_with_object_flag_to_elm_parser(self):
+        d = ObjectFlag(
+            {
+                "hello": CustomTypeFlag(
+                    variants=[
+                        (
+                            "Custom1",
+                            ObjectFlag({"hello": StringFlag(), "world": StringFlag()}),
+                        )
+                    ]
+                )
+            }
+        )
+        SUT = Flags(d)
+
+        assert SUT.to_elm_parser_data()["alias_type"] == (
+            """{ hello : Hello_
+    }
+
+type Hello_
+    = Custom1 Hello_Custom1__
+
+
+type alias Hello_Custom1__ =
+    { hello : String
+    , world : String
+    }"""
+        )
+        assert SUT.to_elm_parser_data()["decoder_body"] == (
+            """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.oneOf [Decode.map Custom1 hello_Custom1__Decoder])
+
+hello_Custom1__Decoder : Decode.Decoder Hello_Custom1__
+hello_Custom1__Decoder =
+    Decode.succeed Hello_Custom1__
+        |> required "hello" Decode.string
+        |> required "world" Decode.string"""
+        )
+
     def test_with_mix_to_elm_parser(self):
         d = ObjectFlag(
             {
@@ -1022,16 +1132,17 @@ class TestObjectFlags:
     }
 
 type alias Hello_ =
-    { world : String
-    }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" hello_Decoder
-        |>  required "someList" (Decode.list Decode.string)
+    { world : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" hello_Decoder
+        |> required "someList" (Decode.list Decode.string)
 
 hello_Decoder : Decode.Decoder Hello_
 hello_Decoder =
     Decode.succeed Hello_
-        |>  required "world" Decode.string""",
+        |> required "world" Decode.string""",
         }
 
     def test_with_list_with_nullable_with_string_to_elm_parser(self):
@@ -1039,10 +1150,12 @@ hello_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """{ hello : (List (Maybe String))
+            "alias_type": """{ hello : List (Maybe String)
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.list (Decode.nullable Decode.string))""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.list (Decode.nullable Decode.string))""",
         }
 
     def test_with_list_with_list_with_string_to_elm_parser(self):
@@ -1050,10 +1163,12 @@ hello_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """{ hello : (List (List String))
+            "alias_type": """{ hello : List (List String)
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.list (Decode.list Decode.string))""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.list (Decode.list Decode.string))""",
         }
 
     def test_with_object_with_string_to_elm_parser(self):
@@ -1065,15 +1180,16 @@ hello_Decoder =
     }
 
 type alias Hello_ =
-    { world : String
-    }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" hello_Decoder
+    { world : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" hello_Decoder
 
 hello_Decoder : Decode.Decoder Hello_
 hello_Decoder =
     Decode.succeed Hello_
-        |>  required "world" Decode.string""",
+        |> required "world" Decode.string""",
         }
 
     def test_with_list_with_object_with_string_to_elm_parser(self):
@@ -1081,29 +1197,32 @@ hello_Decoder =
         SUT = Flags(d)
 
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """{ hello : (List Hello_)
+            "alias_type": """{ hello : List Hello_
     }
 
 type alias Hello_ =
-    { world : String
-    }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.list hello_Decoder)
+    { world : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.list hello_Decoder)
 
 hello_Decoder : Decode.Decoder Hello_
 hello_Decoder =
     Decode.succeed Hello_
-        |>  required "world" Decode.string""",
+        |> required "world" Decode.string""",
         }
 
     def test_with_list_with_string_to_elm_parser(self):
         d = ObjectFlag({"hello": ListFlag(StringFlag())})
         SUT = Flags(d)
         assert SUT.to_elm_parser_data() == {
-            "alias_type": """{ hello : (List String)
+            "alias_type": """{ hello : List String
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.list Decode.string)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.list Decode.string)""",
         }
 
     def test_with_nullable_with_string_to_elm_parser(self):
@@ -1112,8 +1231,10 @@ hello_Decoder =
         assert SUT.to_elm_parser_data() == {
             "alias_type": """{ hello : Maybe String
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.nullable Decode.string)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.nullable Decode.string)""",
         }
 
     def test_with_nullable_with_int_to_elm_parser(self):
@@ -1122,8 +1243,10 @@ hello_Decoder =
         assert SUT.to_elm_parser_data() == {
             "alias_type": """{ hello : Maybe Int
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.nullable Decode.int)""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.nullable Decode.int)""",
         }
 
     def test_with_nullable_with_nullable_with_string_to_elm_parser(self):
@@ -1132,8 +1255,10 @@ hello_Decoder =
         assert SUT.to_elm_parser_data() == {
             "alias_type": """{ hello : Maybe (Maybe String)
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.nullable (Decode.nullable Decode.string))""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.nullable (Decode.nullable Decode.string))""",
         }
 
     def test_with_nullable_with_object_to_elm_parser(self):
@@ -1144,15 +1269,16 @@ hello_Decoder =
     }
 
 type alias Hello_ =
-    { hello : String
-    }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.nullable hello_Decoder)
+    { hello : String }""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.nullable hello_Decoder)
 
 hello_Decoder : Decode.Decoder Hello_
 hello_Decoder =
     Decode.succeed Hello_
-        |>  required "hello" Decode.string""",
+        |> required "hello" Decode.string""",
         }
 
     def test_with_nullable_with_list_with_string_to_elm_parser(self):
@@ -1161,9 +1287,278 @@ hello_Decoder =
         assert SUT.to_elm_parser_data() == {
             "alias_type": """{ hello : Maybe (List String)
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "hello" (Decode.nullable (Decode.list Decode.string))""",
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "hello" (Decode.nullable (Decode.list Decode.string))""",
         }
+
+
+class TestCustomTypeFlags:
+    def test_root_string_flag_custom_type_parser(self):
+        """Handles StringFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", StringFlag())])
+
+        SUT = Flags(d)
+        assert SUT.parse("2") == '"2"'
+
+        with pytest.raises(ValidationError):
+            assert SUT.parse(2)
+
+    def test_root_int_flag_custom_type_parser(self):
+        """Handles IntFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", IntFlag())])
+
+        SUT = Flags(d)
+        assert SUT.parse(2) == "2"
+
+        with pytest.raises(ValidationError):
+            assert SUT.parse(2.0)
+
+    def test_root_float_flag_custom_type_parser(self):
+        """Handles FloatFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", FloatFlag())])
+
+        SUT = Flags(d)
+        assert SUT.parse(2.0) == "2.0"
+        assert SUT.parse(2) == "2.0"
+
+    def test_root_bool_flag_custom_type_parser(self):
+        """Handles BoolFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", BoolFlag())])
+
+        SUT = Flags(d)
+        assert SUT.parse(True) == "true"
+        assert SUT.parse(False) == "false"
+
+    def test_root_nullable_with_string_flag_custom_type_parser(self):
+        """Handles NullableFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", NullableFlag(StringFlag()))])
+
+        SUT = Flags(d)
+        assert SUT.parse(None) == "null"
+        assert SUT.parse("hello") == '"hello"'
+
+    def test_root_list_with_string_flag_custom_type_parser(self):
+        """Handles ListFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", ListFlag(StringFlag()))])
+
+        SUT = Flags(d)
+        assert SUT.parse([]) == "[]"
+        assert SUT.parse(["hello"]) == '["hello"]'
+
+    def test_root_object_flag_with_string_field_custom_type_parser(self):
+        """Handles ObjectFlag"""
+        d = CustomTypeFlag(variants=[("Custom1", ObjectFlag({"hello": StringFlag()}))])
+
+        SUT = Flags(d)
+        assert SUT.parse({"hello": "world"}) == '{"hello":"world"}'
+
+    @pytest.mark.django_db
+    def test_root_mcf_flag_custom_type_parser(self, basic_form):
+        """Handles a ModelChoiceFieldFlag"""
+        prepare_form = basic_form()
+        d = ModelChoiceFieldFlag()
+
+        SUT = Flags(d)
+        d = CustomTypeFlag(variants=[("Custom1", ModelChoiceFieldFlag())])
+
+        assert (
+            SUT.parse(prepare_form["car"])
+            == '{"help_text":"Do I detect.. Elm?","auto_id":"id_car","id_for_label":"id_car","label":"Car","name":"car","widget_type":"select","options":[{"choice_label":"---------","value":"","selected":true}]}'
+        )
+
+    def test_inline_custom_type_with_no_variants_raises(self):
+        d = CustomTypeFlag(variants=[])
+
+        with pytest.raises(Exception):
+            Flags(d)
+
+    def test_inline_custom_type_with_lowercase_variant(self):
+        d = CustomTypeFlag(variants=[("custom1", ObjectFlag({"hello": StringFlag()}))])
+
+        SUT = Flags(d)
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 InlineToModel_Custom1__
+
+
+type alias InlineToModel_Custom1__ =
+    { hello : String }"""
+        )
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 inlinetomodel_Custom1__Decoder])
+
+inlinetomodel_Custom1__Decoder : Decode.Decoder InlineToModel_Custom1__
+inlinetomodel_Custom1__Decoder =
+    Decode.succeed InlineToModel_Custom1__
+        |> required "hello" Decode.string"""
+        )
+
+    def test_root_custom_type_with_string_codegen(self):
+        """Generates String custom type"""
+        d = CustomTypeFlag(variants=[("Custom1", StringFlag())])
+
+        SUT = Flags(d)
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 String
+"""
+        )
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 Decode.string])"""
+        )
+
+    def test_root_custom_type_with_nullable_codegen(self):
+        """Generates String custom type"""
+        d = CustomTypeFlag(variants=[("Custom1", NullableFlag(StringFlag()))])
+
+        SUT = Flags(d)
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 (Maybe String)
+"""
+        )
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 (Decode.nullable Decode.string)])"""
+        )
+
+    def test_root_custom_type_with_list_codegen(self):
+        """Generates String custom type"""
+        d = CustomTypeFlag(variants=[("Custom1", ListFlag(StringFlag()))])
+
+        SUT = Flags(d)
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 (List String)
+"""
+        )
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 (Decode.list Decode.string)])"""
+        )
+
+    def test_root_custom_type_with_list_nullable_codegen(self):
+        """Generates String custom type"""
+        d = CustomTypeFlag(variants=[("Custom1", ListFlag(NullableFlag(StringFlag())))])
+
+        SUT = Flags(d)
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 (List (Maybe String))
+"""
+        )
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 (Decode.list (Decode.nullable Decode.string))])"""
+        )
+
+    def test_root_custom_flag_custom_type_codegen(self):
+        d = CustomTypeFlag(
+            variants=[
+                ("Custom1", CustomTypeFlag(variants=[("InnerCustom", StringFlag())])),
+            ]
+        )
+
+        SUT = Flags(d)
+
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 InlineToModel_Custom1__
+
+
+type InlineToModel_Custom1__
+    = InnerCustom String
+"""
+        )
+
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 (Decode.oneOf [Decode.map InnerCustom Decode.string])])"""
+        )
+
+    def test_root_object_flag_custom_type_codegen(self):
+        """Generates String custom type"""
+        d = CustomTypeFlag(
+            variants=[
+                ("Custom1", ObjectFlag({"hello": StringFlag(), "world": StringFlag()})),
+                ("Custom2", ObjectFlag({"ive": StringFlag(), "arrived": StringFlag()})),
+                ("Custom3", StringFlag()),
+            ]
+        )
+
+        SUT = Flags(d)
+        assert (
+            SUT.to_elm_parser_data()["alias_type"]
+            == """InlineToModel_
+
+type InlineToModel_
+    = Custom1 InlineToModel_Custom1__
+    | Custom2 InlineToModel_Custom2__
+    | Custom3 String
+
+
+type alias InlineToModel_Custom1__ =
+    { hello : String
+    , world : String
+    }
+
+type alias InlineToModel_Custom2__ =
+    { ive : String
+    , arrived : String
+    }"""
+        )
+        assert (
+            SUT.to_elm_parser_data()["decoder_body"]
+            == """toModel : Decode.Decoder ToModel
+toModel =
+    (Decode.oneOf [Decode.map Custom1 inlinetomodel_Custom1__Decoder, Decode.map Custom2 inlinetomodel_Custom2__Decoder, Decode.map Custom3 Decode.string])
+
+inlinetomodel_Custom1__Decoder : Decode.Decoder InlineToModel_Custom1__
+inlinetomodel_Custom1__Decoder =
+    Decode.succeed InlineToModel_Custom1__
+        |> required "hello" Decode.string
+        |> required "world" Decode.string
+
+inlinetomodel_Custom2__Decoder : Decode.Decoder InlineToModel_Custom2__
+inlinetomodel_Custom2__Decoder =
+    Decode.succeed InlineToModel_Custom2__
+        |> required "ive" Decode.string
+        |> required "arrived" Decode.string"""
+        )
 
 
 class TestModelChoiceFieldFlags:
@@ -1219,19 +1614,21 @@ type alias Options_ =
     , value : String
     , selected : Bool
     }""",
-            "decoder_body": """Decode.succeed ToModel
-        |>  required "help_text" Decode.string
-        |>  required "auto_id" Decode.string
-        |>  required "id_for_label" Decode.string
-        |>  required "label" (Decode.nullable Decode.string)
-        |>  required "name" Decode.string
-        |>  required "widget_type" Decode.string
-        |>  required "options" (Decode.list options_Decoder)
+            "decoder_body": """toModel : Decode.Decoder ToModel
+toModel =
+    Decode.succeed ToModel
+        |> required "help_text" Decode.string
+        |> required "auto_id" Decode.string
+        |> required "id_for_label" Decode.string
+        |> required "label" (Decode.nullable Decode.string)
+        |> required "name" Decode.string
+        |> required "widget_type" Decode.string
+        |> required "options" (Decode.list options_Decoder)
 
 options_Decoder : Decode.Decoder Options_
 options_Decoder =
     Decode.succeed Options_
-        |>  required "choice_label" Decode.string
-        |>  required "value" Decode.string
-        |>  required "selected" Decode.bool""",
+        |> required "choice_label" Decode.string
+        |> required "value" Decode.string
+        |> required "selected" Decode.bool""",
         }


### PR DESCRIPTION
Related #77 

## Included
- Python to Elm compiler for code generation
- Map python values to Elm Custom types

## Python to Elm compiler
"Compiler" is a stretch, although that is what it's doing. I supported a very limited set of Elm so I can more easily create expressions, annotations and declarations dynamically. Previously this was being done via string wrangling and it was a god damn pain. This ended working out great.

Heavily inspired by the very excellent [mdgriffith/elm-codegen](https://package.elm-lang.org/packages/mdgriffith/elm-codegen/latest/)
