### PR TITLE
StringFlag literals

### DIFF
--- a/src/djelm/codegen/expression.py
+++ b/src/djelm/codegen/expression.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import typing as Typ
 import djelm.codegen.module_name as Mod
+from djelm.codegen.pattern import Pattern
 import djelm.codegen.range as Range
 import djelm.codegen.compiler as Compiler
 
@@ -168,6 +169,47 @@ class Application(Compiler.Expression):
 class Parenthesized(Compiler.Expression):
     expression: Compiler.Expression
     range: Range.Range | None
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class Lambda(Compiler.Expression):
+    args: list[Pattern]
+    expression: Compiler.Expression
+
+    def annotation_type(self) -> Compiler.TypeAnnotation | None:
+        return None
+
+    def set_range(self, rng: Range.Range) -> None:
+        self.range = rng
+
+    def set_range_column(self, start: int) -> None:
+        new_range = self.get_range()
+        new_range.column = start
+        self.range = new_range
+
+    def get_range(self) -> Range.Range:
+        return self.range or Range.Range(0, 0)
+
+
+@dataclass(slots=True)
+class IfBlock(Compiler.Expression):
+    condition: Compiler.Expression
+    then_case: Compiler.Expression
+    else_case: Compiler.Expression
 
     def annotation_type(self) -> Compiler.TypeAnnotation | None:
         return None

--- a/src/djelm/codegen/op.py
+++ b/src/djelm/codegen/op.py
@@ -3,6 +3,12 @@ import djelm.codegen.expression as Exp
 import djelm.codegen.compiler as Compiler
 
 
+def equals(
+    left: Compiler.Expression, right: Compiler.Expression
+) -> Compiler.Expression:
+    return Exp.OperatorApplication("==", "Left", left, right, None)
+
+
 def plus(left: Compiler.Expression, right: Compiler.Expression) -> Compiler.Expression:
     return Exp.OperatorApplication("+", "Left", left, right, None)
 

--- a/src/djelm/codegen/pattern.py
+++ b/src/djelm/codegen/pattern.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+class Pattern:
+    pass
+
+
+@dataclass(slots=True)
+class VarPattern(Pattern):
+    value: str

--- a/src/djelm/flags/README.md
+++ b/src/djelm/flags/README.md
@@ -13,8 +13,16 @@ You can find a good explanation for djelm flags with examples in the official gu
 
 # StringFlag
 
+### Args
+
+literal : str
+
 ```python
 StringFlag()
+
+# Match against a literal string
+
+StringFlag(literal="hello")
 ```
 
 ```

--- a/src/djelm/flags/adapters.py
+++ b/src/djelm/flags/adapters.py
@@ -1,6 +1,25 @@
 from typing_extensions import Annotated
+import typing
 
-from pydantic import Field, Strict, TypeAdapter
+from pydantic import BeforeValidator, Field, Strict, TypeAdapter
+
+
+def match_literal(v: str) -> typing.Callable[[str], str]:
+    def do_match(v1):
+        if v != v1:
+            raise Exception(f"#{v} does not match #{v1} for string literal flag")
+        else:
+            return v1
+
+    return do_match
+
+
+def string_literal_adapter(v: str):
+    return TypeAdapter(Annotated[str, Strict(), BeforeValidator(match_literal(v))])  # type:ignore
+
+
+def annotated_string_literal(v: str):
+    return Annotated[str, Strict(), BeforeValidator(match_literal(v))]
 
 
 annotated_string = Annotated[str, Strict()]

--- a/src/djelm/flags/primitives.py
+++ b/src/djelm/flags/primitives.py
@@ -10,7 +10,15 @@ class Flag:
 
 @dataclass(slots=True)
 class StringFlag(Flag):
-    """Flag for the Elm String primitive"""
+    """Flag for the Elm String primitive
+
+    literal :
+        Will match against the passed string literal.
+
+        Generated decoders will also express the string literal
+    """
+
+    literal: str | None = None
 
 
 @dataclass(slots=True)

--- a/tests/fuzz_flags.py
+++ b/tests/fuzz_flags.py
@@ -30,7 +30,10 @@ ALL_FLAGS = [
 
 def generate_alias_keys() -> list[str]:
     keys = st.lists(
-        st.from_regex(regex=r"^[a-z][A-Za-z0-9_]*$"), min_size=1, max_size=5
+        # Added lookahead for reserved keywords
+        st.from_regex(regex=r"^(?!\bif\W*$)[a-z][A-Za-z0-9_]*$"),
+        min_size=1,
+        max_size=5,
     ).example()
     return keys
 


### PR DESCRIPTION
Helps #99 

## Improvements
- `StringFlag` can now match literals.

```python
flag = StringFlag(literal="hello")
flag.parse("hello") # Passes
flag.parse("Hello") # Fails
```

- Generated decoders express the literal match

```elm
Decode.string |> Decode.andthen (\lit -> lit == "hello" then Decode.succeed "hello" else Decode.fail "...")
```