### PR TITLE
Handle die more gracefully

### DIFF
--- a/packages/transformer-elm/lib/ElmTransformer.js
+++ b/packages/transformer-elm/lib/ElmTransformer.js
@@ -104,8 +104,8 @@ exports.default = new plugin_1.Transformer({
         const injection = `
       const die = function () {
         managers = null;
-        model = null;
-        stepper = null;
+        model = { $: null };
+        stepper = () => {};
         ports = null;
       };
       return ports ? {

--- a/packages/transformer-elm/package.json
+++ b/packages/transformer-elm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confidenceman02/parcel-transformer-djelm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Parcel transformer for the djelm framework",
   "main": "lib/ElmTransformer.js",
   "source": "src/ElmTransformer.ts",

--- a/packages/transformer-elm/src/ElmTransformer.ts
+++ b/packages/transformer-elm/src/ElmTransformer.ts
@@ -79,8 +79,8 @@ export default new Transformer({
     const injection = `
       const die = function () {
         managers = null;
-        model = null;
-        stepper = null;
+        model = { $: null };
+        stepper = () => {};
         ports = null;
       };
       return ports ? {


### PR DESCRIPTION
It's possible for djelm to kill programs that have tasks in flight so we need a bit more of a gentle touch when doing the killing.

We are still nullifying the model but we give it a shape the kernel code will more gracefully handle.
