### PR TITLE
Fix wrong username

### DIFF
--- a/packages/transformer-elm/LICENSE.txt
+++ b/packages/transformer-elm/LICENSE.txt
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2025 confidenceman
+Copyright (c) 2025 Confidenceman02
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/transformer-elm/README.md
+++ b/packages/transformer-elm/README.md
@@ -1,6 +1,6 @@
 # @confidenceman02/parcel-transformer-djelm
 
-A Parcel V2 transformer for the [djelm](https://github.com/confidenceman/django-elm) framework. It enables you to compile Elm files directly within your Parcel project.
+A Parcel V2 transformer for the [djelm](https://github.com/Confidenceman02/django-elm) framework. It enables you to compile Elm files directly within your Parcel project.
 
 ## Features
 
@@ -55,7 +55,7 @@ When Parcel's `shouldOptimize` flag is set (which is the default for production 
 
 ## Repository
 
-This package is part of the [django-elm](https://github.com/confidenceman/django-elm) monorepo. For issues, contributions, and more information, please visit the main repository.
+This package is part of the [django-elm](https://github.com/Confidenceman02/django-elm) monorepo. For issues, contributions, and more information, please visit the main repository.
 
 ## License
 

--- a/packages/transformer-elm/package.json
+++ b/packages/transformer-elm/package.json
@@ -30,13 +30,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/confidenceman/django-elm.git",
+    "url": "https://github.com/Confidenceman02/django-elm.git",
     "directory": "packages/transformer-elm"
   },
   "bugs": {
-    "url": "https://github.com/confidenceman/django-elm/issues"
+    "url": "https://github.com/Confidenceman02/django-elm/issues"
   },
-  "homepage": "https://github.com/confidenceman/django-elm/tree/main/packages/transformer-elm#readme",
+  "homepage": "https://github.com/Confidenceman02/django-elm/tree/main/packages/transformer-elm#readme",
   "dependencies": {
     "@parcel/diagnostic": "^2.15.4",
     "@parcel/plugin": "^2.15.4",

--- a/packages/transformer-elm/src/ElmTransformer.ts
+++ b/packages/transformer-elm/src/ElmTransformer.ts
@@ -135,7 +135,7 @@ function formatElmError(
 
   return {
     message,
-    origin: "@confidenceman/parcel-transformer-djelm",
+    origin: "@confidenceman02/parcel-transformer-djelm",
     stack: "", // set stack to empty since it is not useful
   };
 }


### PR DESCRIPTION
I noticed broken links on https://www.npmjs.com/package/@confidenceman02/parcel-transformer-djelm due to the wrong username being used and thought I’d fix that.